### PR TITLE
refactoring: Move insert_documents to execute ql

### DIFF
--- a/integration/cpp/test/test_collection_ql.cpp
+++ b/integration/cpp/test/test_collection_ql.cpp
@@ -19,6 +19,7 @@ TEST_CASE("integration::cpp::test_collection::ql") {
     test_clear_directory(config);
     config.disk.on = false;
     config.wal.on = false;
+    
     test_spaces space(config);
     auto* dispatcher = space.dispatcher();
 

--- a/integration/cpp/test/test_config.hpp
+++ b/integration/cpp/test/test_config.hpp
@@ -11,6 +11,8 @@ inline configuration::config test_create_config(const std::filesystem::path &pat
     config.log.path = path;
     config.disk.path = path;
     config.wal.path = path;
+    // To change log level
+    // config.log.level =log_t::level::trace;
     return config;
 }
 

--- a/integration/cpp/test/test_save_load.cpp
+++ b/integration/cpp/test/test_save_load.cpp
@@ -5,8 +5,8 @@
 #include "test_config.hpp"
 
 constexpr uint count_databases = 2;
-constexpr uint count_collections = 5;
-constexpr uint count_documents = 10;
+constexpr uint count_collections = 4;
+constexpr uint count_documents = 8;
 
 static const database_name_t database_name = "TestDatabase";
 static const collection_name_t collection_name = "TestCollection";
@@ -79,7 +79,7 @@ TEST_CASE("python::test_save_load::disk") {
 }
 
 
-TEST_CASE("python::test_save_load::disk+wal") {
+ TEST_CASE("python::test_save_load::disk+wal") {
     auto config = test_create_config("/tmp/test_save_load/wal");
 
     SECTION("initialization") {

--- a/integration/cpp/wrapper_dispatcher.hpp
+++ b/integration/cpp/wrapper_dispatcher.hpp
@@ -34,8 +34,8 @@ namespace ottergon {
         [[deprecated]] auto drop_database(session_id_t &session, const database_name_t &database) -> components::result::result_t;
         [[deprecated]] auto create_collection(session_id_t &session, const database_name_t &database, const collection_name_t &collection) -> components::result::result_t;
         [[deprecated]] auto drop_collection(session_id_t &session, const database_name_t &database, const collection_name_t &collection) -> components::result::result_t;
-        [[deprecated]] auto insert_one(session_id_t &session, const database_name_t &database, const collection_name_t &collection, document_ptr &document) -> components::result::result_insert&;
-        [[deprecated]] auto insert_many(session_id_t &session, const database_name_t &database, const collection_name_t &collection, std::pmr::vector<document_ptr> &documents) -> components::result::result_insert&;
+        [[deprecated]] auto insert_one(session_id_t &session, const database_name_t &database, const collection_name_t &collection, document_ptr &document) -> components::result::result_t&;
+        [[deprecated]] auto insert_many(session_id_t &session, const database_name_t &database, const collection_name_t &collection, std::pmr::vector<document_ptr> &documents) -> components::result::result_t&;
         [[deprecated]] auto find(session_id_t &session, components::ql::aggregate_statement_raw_ptr condition) -> components::result::result_t;
         [[deprecated]] auto find_one(session_id_t &session, components::ql::aggregate_statement_raw_ptr condition) -> components::result::result_t;
         [[deprecated]] auto delete_one(session_id_t &session, components::ql::aggregate_statement_raw_ptr condition) -> components::result::result_delete&;

--- a/integration/python/wrapper_collection.cpp
+++ b/integration/python/wrapper_collection.cpp
@@ -65,6 +65,10 @@ namespace ottergon {
             generate_document_id_if_not_exists(doc);
             auto session_tmp = ottergon::session_id_t();
             auto result_variant = ptr_->insert_one(session_tmp, database_, name_, doc);
+            if(result_variant.is_error()){
+                debug(log_, "wrapper_collection::insert_one has result error while insert");
+                throw std::runtime_error("wrapper_collection::insert_one error_result");
+            }
             assert(result_variant.is_type<components::result::result_insert>() && "wrapper_collection::insert_one result error");
             auto& result = result_variant.get<components::result::result_insert>();
             debug(log_, "wrapper_collection::insert_one {} inserted", result.inserted_ids().empty() ? 0 : 1);
@@ -85,6 +89,10 @@ namespace ottergon {
             }
             auto session_tmp = ottergon::session_id_t();
             auto result_variant = ptr_->insert_many(session_tmp, database_, name_, docs);
+            if(result_variant.is_error()){
+                debug(log_, "wrapper_collection::insert_many has result error while insert");
+                throw std::runtime_error("wrapper_collection::insert_many error_result");
+            }
             assert(result_variant.is_type<components::result::result_insert>() && "wrapper_collection::insert_many result error");
             auto& result = result_variant.get<components::result::result_insert>();
             debug(log_, "wrapper_collection::insert_many {} inserted", result.inserted_ids().size());

--- a/integration/python/wrapper_collection.cpp
+++ b/integration/python/wrapper_collection.cpp
@@ -64,7 +64,9 @@ namespace ottergon {
             auto doc = to_document(document);
             generate_document_id_if_not_exists(doc);
             auto session_tmp = ottergon::session_id_t();
-            auto result = ptr_->insert_one(session_tmp, database_, name_, doc);
+            auto result_variant = ptr_->insert_one(session_tmp, database_, name_, doc);
+            assert(result_variant.is_type<components::result::result_insert>() && "wrapper_collection::insert_one result error");
+            auto& result = result_variant.get<components::result::result_insert>();
             debug(log_, "wrapper_collection::insert_one {} inserted", result.inserted_ids().empty() ? 0 : 1);
             return result.inserted_ids().empty() ? result.inserted_ids().front().to_string() : std::string();
         }
@@ -82,7 +84,9 @@ namespace ottergon {
                 docs.push_back(std::move(doc));
             }
             auto session_tmp = ottergon::session_id_t();
-            auto result = ptr_->insert_many(session_tmp, database_, name_, docs);
+            auto result_variant = ptr_->insert_many(session_tmp, database_, name_, docs);
+            assert(result_variant.is_type<components::result::result_insert>() && "wrapper_collection::insert_many result error");
+            auto& result = result_variant.get<components::result::result_insert>();
             debug(log_, "wrapper_collection::insert_many {} inserted", result.inserted_ids().size());
             py::list list;
             for (const auto& id : result.inserted_ids()) {

--- a/services/collection/collection.hpp
+++ b/services/collection/collection.hpp
@@ -94,11 +94,6 @@ namespace services::collection {
                 const components::logical_plan::node_ptr& logical_plan,
                 components::ql::storage_parameters parameters) -> void;
 
-        auto insert_documents(
-                const components::session::session_id_t& session,
-                const components::logical_plan::node_ptr& logic_plan,
-                components::ql::storage_parameters parameters) -> void;
-
         auto delete_documents(
                 const components::session::session_id_t& session,
                 const components::logical_plan::node_ptr& logic_plan,

--- a/services/collection/route.hpp
+++ b/services/collection/route.hpp
@@ -7,7 +7,6 @@ namespace services::collection {
     enum class route : uint64_t {
         create_documents,
         execute_plan,
-        insert_documents,
         delete_documents,
         update_documents,
         size,
@@ -18,7 +17,6 @@ namespace services::collection {
 
         create_documents_finish,
         execute_plan_finish,
-        insert_finish,
         delete_finish,
         update_finish,
         size_finish,

--- a/services/disk/disk.cpp
+++ b/services/disk/disk.cpp
@@ -81,6 +81,7 @@ namespace services::disk {
             id_documents.push_back(it->key().ToString());
         }
         delete it;
+
         return id_documents;
     }
 

--- a/services/disk/manager_disk.cpp
+++ b/services/disk/manager_disk.cpp
@@ -130,7 +130,6 @@ namespace services::disk {
                     }
                     if (indexes.empty()) {
                         actor_zeta::send(agent(), address(), command.name(), command);
-                        actor_zeta::send(current_message()->sender(), address(), handler_id(route::remove_collection_finish), session, drop_collection.collection);
                     } else {
                         removed_indexes_.emplace(session, removed_index_t{indexes.size(), command, current_message()->sender()});
                         for (auto *index : indexes) {
@@ -195,7 +194,6 @@ namespace services::disk {
                     actor_zeta::send(agent(), address(), it_all_drop->second.command.name(), it_all_drop->second.command);
                     const auto& drop_collection = it_all_drop->second.command.get<command_remove_collection_t>();
                     remove_all_indexes_from_collection_(drop_collection.collection);
-                    actor_zeta::send(it_all_drop->second.sender, address(), handler_id(route::remove_collection_finish), session, drop_collection.collection);
                 }
             }
         }

--- a/services/disk/route.hpp
+++ b/services/disk/route.hpp
@@ -15,7 +15,6 @@ namespace services::disk {
 
         append_collection,
         remove_collection,
-        remove_collection_finish,
 
         write_documents,
         remove_documents,

--- a/services/dispatcher/dispatcher.cpp
+++ b/services/dispatcher/dispatcher.cpp
@@ -89,7 +89,7 @@ namespace services::dispatcher {
         load_result_.clear();
     }
 
-    void dispatcher_t::load_from_wal_result(components::session::session_id_t& session, std::vector<services::wal::record_t> in_records) {
+    void dispatcher_t::load_from_wal_result(components::session::session_id_t& session, std::vector<services::wal::record_t>& in_records) {
         // TODO think what to do with records
         records_ = std::move(in_records);
         load_count_answers_ = records_.size();
@@ -180,7 +180,7 @@ namespace services::dispatcher {
                     assert(std::holds_alternative<create_index_t>(record.data) && "[dispatcher_t::load_from_wal_result]: [ case: statement_type::create_index] variant record.data holds the alternative create_index_t");
                     auto& data = std::get<create_index_t>(record.data);
                     components::session::session_id_t session_create_index;
-                    create_index(session_create_index, std::move(data), manager_wal_);
+                    create_index(session_create_index, data, manager_wal_);
                     break;
                 }
                 default:

--- a/services/dispatcher/dispatcher.cpp
+++ b/services/dispatcher/dispatcher.cpp
@@ -37,12 +37,9 @@ namespace services::dispatcher {
         add_handler(core::handler_id(core::route::load), &dispatcher_t::load);
         add_handler(disk::handler_id(disk::route::load_finish), &dispatcher_t::load_from_disk_result);
         add_handler(memory_storage::handler_id(memory_storage::route::load_finish), &dispatcher_t::load_from_memory_resource_result);
-        add_handler(disk::handler_id(disk::route::remove_collection_finish), &dispatcher_t::drop_collection_finish_from_disk);
         add_handler(wal::handler_id(wal::route::load_finish), &dispatcher_t::load_from_wal_result);
         add_handler(handler_id(route::execute_ql), &dispatcher_t::execute_ql);
         add_handler(memory_storage::handler_id(memory_storage::route::execute_plan_finish), &dispatcher_t::execute_ql_finish);
-        add_handler(collection::handler_id(collection::route::insert_documents), &dispatcher_t::insert_documents);
-        add_handler(collection::handler_id(collection::route::insert_finish), &dispatcher_t::insert_finish);
         add_handler(collection::handler_id(collection::route::delete_documents), &dispatcher_t::delete_documents);
         add_handler(collection::handler_id(collection::route::delete_finish), &dispatcher_t::delete_finish);
         add_handler(collection::handler_id(collection::route::update_documents), &dispatcher_t::update_documents);
@@ -92,90 +89,96 @@ namespace services::dispatcher {
         load_result_.clear();
     }
 
-    void dispatcher_t::load_from_wal_result(components::session::session_id_t& session, std::vector<services::wal::record_t> &records) {
-        load_count_answers_ = records.size();
+    void dispatcher_t::load_from_wal_result(components::session::session_id_t& session, std::vector<services::wal::record_t> in_records) {
+        // TODO think what to do with records
+        records_ = std::move(in_records);
+        load_count_answers_ = records_.size();
         trace(log_, "dispatcher_t::load_from_wal_result, session: {}, count commands: {}", session.data(), load_count_answers_);
         if (load_count_answers_ == 0) {
+            trace(log_, "dispatcher_t::load_from_wal_result - empty records_");
             actor_zeta::send(find_session(session_to_address_, session).address(), dispatcher_t::address(), core::handler_id(core::route::load_finish));
             remove_session(session_to_address_, session);
             return;
         }
-        last_wal_id_ = records[load_count_answers_ - 1].id;
-        for (const auto &record : records) {
+        last_wal_id_ = records_[load_count_answers_ - 1].id;
+        for (auto &record : records_) {
             switch (record.type) {
                 case statement_type::create_database: {
                     assert(std::holds_alternative<create_database_t>(record.data) && "[dispatcher_t::load_from_wal_result]: [ case: statement_type::create_database] variant record.data holds the alternative create_database_t");
-                    auto data = std::get<create_database_t>(record.data);
+                    auto& data = std::get<create_database_t>(record.data);
                     components::session::session_id_t session_database;
                     execute_ql(session_database, &data, manager_wal_);
                     break;
                 }
                     case statement_type::drop_database: {
                     assert(std::holds_alternative<drop_database_t>(record.data) && "[dispatcher_t::load_from_wal_result]: [ case: statement_type::drop_database] variant record.data holds the alternative drop_database_t");
-                    auto data = std::get<drop_database_t>(record.data);
+                    auto& data = std::get<drop_database_t>(record.data);
                     components::session::session_id_t session_database;
                     execute_ql(session_database, &data, manager_wal_);
                     break;
                 }
                     case statement_type::create_collection: {
                     assert(std::holds_alternative<create_collection_t>(record.data) && "[dispatcher_t::load_from_wal_result]: [ case: statement_type::create_collection] variant record.data holds the alternative create_collection_t");
-                    auto data = std::get<create_collection_t>(record.data);
+                    auto& data = std::get<create_collection_t>(record.data);
                     components::session::session_id_t session_collection;
                     execute_ql(session_collection, &data, manager_wal_);
                     break;
                 }
                 case statement_type::drop_collection: {
                     assert(std::holds_alternative<drop_collection_t>(record.data) && "[dispatcher_t::load_from_wal_result]: [ case: statement_type::drop_collection] variant record.data holds the alternative drop_collection_t");
-                    auto data = std::get<drop_collection_t>(record.data);
+                    auto& data = std::get<drop_collection_t>(record.data);
                     components::session::session_id_t session_collection;
                     execute_ql(session_collection, &data, manager_wal_);
                     break;
                 }
                 case statement_type::insert_one: {
+                    trace(log_, "dispatcher_t::load_from_wal_result: insert_one {}", session.data());
                     assert(std::holds_alternative<insert_one_t>(record.data) && "[dispatcher_t::load_from_wal_result]: [ case: statement_type::insert_one] variant record.data holds the alternative insert_one_t");
-                    auto ql = std::get<insert_one_t>(record.data);
+                    auto& ql = std::get<insert_one_t>(record.data);
                     components::session::session_id_t session_insert;
-                    insert_documents(session_insert, &ql, manager_wal_);
+                    execute_ql(session_insert, &ql, manager_wal_);
                     break;
                 }
                 case statement_type::insert_many: {
+                    trace(log_, "dispatcher_t::load_from_wal_result: insert_many {}", session.data());
                     assert(std::holds_alternative<insert_many_t>(record.data) && "[dispatcher_t::load_from_wal_result]: [ case: statement_type::insert_many] variant record.data holds the alternative insert_many_t");
-                    auto ql = std::get<insert_many_t>(record.data);
+                    auto& ql = std::get<insert_many_t>(record.data);
                     components::session::session_id_t session_insert;
-                    insert_documents(session_insert, &ql, manager_wal_);
+                    execute_ql(session_insert, &ql, manager_wal_);
                     break;
                 }
                 case statement_type::delete_one: {
                     assert(std::holds_alternative<delete_one_t>(record.data) && "[dispatcher_t::load_from_wal_result]: [ case: statement_type::delete_one] variant record.data holds the alternative delete_one_t");
-                    auto ql = std::get<delete_one_t>(record.data);
+                    auto& ql = std::get<delete_one_t>(record.data);
                     components::session::session_id_t session_delete;
                     delete_documents(session_delete, &ql, manager_wal_);
                     break;
                 }
                 case statement_type::delete_many: {
                     assert(std::holds_alternative<delete_many_t>(record.data) && "[dispatcher_t::load_from_wal_result]: [ case: statement_type::delete_many] variant record.data holds the alternative delete_many_t");
-                    auto ql = std::get<delete_many_t>(record.data);
+                    auto& ql = std::get<delete_many_t>(record.data);
                     components::session::session_id_t session_delete;
                     delete_documents(session_delete, &ql, manager_wal_);
                     break;
                 }
                 case statement_type::update_one: {
+                    trace(log_, "dispatcher_t::load_from_wal_result: update_one {}", session.data());
                     assert(std::holds_alternative<update_one_t>(record.data) && "[dispatcher_t::load_from_wal_result]: [ case: statement_type::update_one] variant record.data holds the alternative update_one_t");
-                    auto ql = std::get<update_one_t>(record.data);
+                    auto& ql = std::get<update_one_t>(record.data);
                     components::session::session_id_t session_update;
                     update_documents(session_update, &ql, manager_wal_);
                     break;
                 }
                 case statement_type::update_many: {
                     assert(std::holds_alternative<update_many_t>(record.data) && "[dispatcher_t::load_from_wal_result]: [ case: statement_type::update_many] variant record.data holds the alternative update_many_t");
-                    auto ql = std::get<update_many_t>(record.data);
+                    auto& ql = std::get<update_many_t>(record.data);
                     components::session::session_id_t session_update;
                     update_documents(session_update, &ql, manager_wal_);
                     break;
                 }
                 case statement_type::create_index: {
                     assert(std::holds_alternative<create_index_t>(record.data) && "[dispatcher_t::load_from_wal_result]: [ case: statement_type::create_index] variant record.data holds the alternative create_index_t");
-                    auto data = std::get<create_index_t>(record.data);
+                    auto& data = std::get<create_index_t>(record.data);
                     components::session::session_id_t session_create_index;
                     create_index(session_create_index, std::move(data), manager_wal_);
                     break;
@@ -195,32 +198,63 @@ namespace services::dispatcher {
     }
 
     void dispatcher_t::execute_ql_finish(components::session::session_id_t& session, const result_t& result) {
+        result_storage_[session] = result;
         auto& s = find_session(session_to_address_, session);
         auto* ql = s.get<ql_statement_t*>();
         trace(log_, "dispatcher_t::execute_ql_finish: session {}, {}, {}", session.data(), ql->to_string(), result.is_success());
         if (result.is_success()) {
             //todo: delete
-
+            
             if (ql->type() == statement_type::create_database) {
+                trace(log_, "dispatcher_t::execute_ql_finish: create_database");
                 actor_zeta::send(manager_disk_, dispatcher_t::address(), disk::handler_id(disk::route::append_database), session, ql->database_);
                 if (find_session(session_to_address_, session).address().get() == manager_wal_.get()) {
                     wal_success(session, last_wal_id_);
                 } else {
                     actor_zeta::send(manager_wal_, dispatcher_t::address(), wal::handler_id(wal::route::create_database), session, *static_cast<create_database_t*>(ql));
+                    return;
                 }
             }
 
             if (ql->type() == statement_type::create_collection) {
+                trace(log_, "dispatcher_t::execute_ql_finish: create_collection");
                 collection_address_book_.emplace(collection_full_name_t(ql->database_, ql->collection_), result.get<result_address_t>().address);
                 actor_zeta::send(manager_disk_, dispatcher_t::address(), disk::handler_id(disk::route::append_collection), session, ql->database_, ql->collection_);
                 if (find_session(session_to_address_, session).address().get() == manager_wal_.get()) {
                     wal_success(session, last_wal_id_);
                 } else {
                     actor_zeta::send(manager_wal_, dispatcher_t::address(), wal::handler_id(wal::route::create_collection), session, *static_cast<create_collection_t*>(ql));
+                    return;
+                }
+            }
+            
+
+            if(ql->type() == statement_type::insert_one){
+                trace(log_, "dispatcher_t::execute_ql_finish: insert_one");
+                if (s.address().get() == manager_wal_.get()) {
+                    wal_success(session, last_wal_id_);
+                } else {
+                    assert(s.is_type<ql_statement_t*>() && "Doesn't holds ql_statement_t*");
+                    auto result = *static_cast<components::ql::insert_one_t*>(s.get<ql_statement_t*>());
+                    actor_zeta::send(manager_wal_, dispatcher_t::address(), wal::handler_id(wal::route::insert_one), session, std::move(result));
+                    return;
+                }
+            }
+
+            if(ql->type() == statement_type::insert_many){
+                trace(log_, "dispatcher_t::execute_ql_finish: insert_many");
+                if (s.address().get() == manager_wal_.get()) {
+                    wal_success(session, last_wal_id_);
+                } else {
+                    assert(s.is_type<ql_statement_t*>() && "Doesn't holds ql_statement_t*");
+                    auto result = *static_cast<components::ql::insert_many_t*>(s.get<ql_statement_t*>());
+                    actor_zeta::send(manager_wal_, dispatcher_t::address(), wal::handler_id(wal::route::insert_many), session, std::move(result));
+                    return;
                 }
             }
 
             if (ql->type() == statement_type::drop_collection) {
+                trace(log_, "dispatcher_t::execute_ql_finish: drop_collection");
                 collection_full_name_t name(ql->database_, ql->collection_);
                 collection_address_book_.erase(name);
                 actor_zeta::send(manager_disk_, dispatcher_t::address(), disk::handler_id(disk::route::remove_collection), session, ql->database_, ql->collection_);
@@ -228,59 +262,15 @@ namespace services::dispatcher {
                     wal_success(session, last_wal_id_);
                 } else {
                     actor_zeta::send(manager_wal_, dispatcher_t::address(), wal::handler_id(wal::route::drop_collection), session, components::ql::drop_collection_t(ql->database_, ql->collection_));
+                    return;
                 }
-                return;
             }
 
             //end: delete
         }
+        // TODO add verification for mutable types (they should be skipped too)
         if (!check_load_from_wal(session)) {
             actor_zeta::send(s.address(), dispatcher_t::address(), handler_id(route::execute_ql_finish), session, result);
-            remove_session(session_to_address_, session);
-        }
-    }
-
-    void dispatcher_t::drop_collection_finish_from_disk(components::session::session_id_t& session, std::string& collection_name) {
-        trace(log_, "dispatcher_t::drop_collection_finish_from_disk: {}", collection_name);
-        if (!check_load_from_wal(session)) {
-            auto address = find_session(session_to_address_, session).address();
-            remove_session(session_to_address_, session);
-            actor_zeta::send(address, dispatcher_t::address(), handler_id(route::execute_ql_finish), session,
-                             components::result::make_result(components::result::empty_result_t()));
-        }
-    }
-
-    void dispatcher_t::insert_documents(components::session::session_id_t& session, ql_statement_t* statement, actor_zeta::address_t address) {
-        trace(log_, "dispatcher_t::insert: session:{}, database: {}, collection: {}", session.data(), statement->database_, statement->collection_);
-        collection_full_name_t key{statement->database_, statement->collection_};
-        auto it_collection = collection_address_book_.find(key);
-        if (it_collection != collection_address_book_.end()) {
-            if (statement->type() == statement_type::insert_one) {
-                make_session(session_to_address_, session, session_t(std::move(address), *static_cast<insert_one_t*>(statement)));
-            } else {
-                make_session(session_to_address_, session, session_t(std::move(address), *static_cast<insert_many_t*>(statement)));
-            }
-            auto logic_plan = create_logic_plan(statement).first;
-            actor_zeta::send(it_collection->second, dispatcher_t::address(), collection::handler_id(collection::route::insert_documents), session, logic_plan, components::ql::storage_parameters{});
-        } else {
-            actor_zeta::send(address, dispatcher_t::address(), collection::handler_id(collection::route::insert_finish), session, result_insert(resource_));
-        }
-    }
-
-    void dispatcher_t::insert_finish(components::session::session_id_t& session, result_insert& result) {
-        trace(log_, "dispatcher_t::insert_finish session: {}", session.data());
-        auto& s = find_session(session_to_address_, session);
-        if (s.address().get() == manager_wal_.get()) {
-            wal_success(session, last_wal_id_);
-        } else {
-            if (s.type() == statement_type::insert_one) {
-                actor_zeta::send(manager_wal_, dispatcher_t::address(), wal::handler_id(wal::route::insert_one), session, s.get<insert_one_t>());
-            } else {
-                actor_zeta::send(manager_wal_, dispatcher_t::address(), wal::handler_id(wal::route::insert_many), session, s.get<insert_many_t>());
-            }
-        }
-        if (!check_load_from_wal(session)) {
-            actor_zeta::send(s.address(), dispatcher_t::address(), collection::handler_id(collection::route::insert_finish), session, result);
             remove_session(session_to_address_, session);
         }
     }
@@ -438,7 +428,26 @@ namespace services::dispatcher {
     }
 
     void dispatcher_t::wal_success(components::session::session_id_t& session, services::wal::id_t wal_id) {
+        trace(log_, "dispatcher_t::wal_success session : {}, wal id: {}", session.data(), wal_id);
         actor_zeta::send(manager_disk_, dispatcher_t::address(), disk::handler_id(disk::route::flush), session, wal_id);
+
+        if(!is_session_exist(session_to_address_, session)){
+            return;
+        }
+        
+        auto session_obj = find_session(session_to_address_, session);
+        const bool is_from_wal = session_obj.address().get() == manager_wal_.get();
+        if(is_from_wal){
+            return;
+        }
+
+        trace(log_, "dispatcher_t::wal_success remove session : {}, wal id: {}", session.data(), wal_id);
+        auto result = result_storage_[session];
+        actor_zeta::send(session_obj.address(), dispatcher_t::address(), handler_id(route::execute_ql_finish), session, result);
+        remove_session(session_to_address_, session);
+        result_storage_.erase(session);
+        
+
     }
 
     bool dispatcher_t::check_load_from_wal(components::session::session_id_t& session) {
@@ -475,7 +484,6 @@ namespace services::dispatcher {
         add_handler(handler_id(route::create), &manager_dispatcher_t::create);
         add_handler(core::handler_id(core::route::load), &manager_dispatcher_t::load);
         add_handler(handler_id(route::execute_ql), &manager_dispatcher_t::execute_ql);
-        add_handler(collection::handler_id(collection::route::insert_documents), &manager_dispatcher_t::insert_documents);
         add_handler(collection::handler_id(collection::route::delete_documents), &manager_dispatcher_t::delete_documents);
         add_handler(collection::handler_id(collection::route::update_documents), &manager_dispatcher_t::update_documents);
         add_handler(collection::handler_id(collection::route::size), &manager_dispatcher_t::size);
@@ -520,11 +528,6 @@ namespace services::dispatcher {
     void manager_dispatcher_t::execute_ql(components::session::session_id_t& session, ql_statement_t* ql) {
         trace(log_, "manager_dispatcher_t::execute_ql session: {}, {}", session.data(), ql->to_string());
         return actor_zeta::send(dispatcher(), address(), handler_id(route::execute_ql), session, ql, current_message()->sender());
-    }
-
-    void manager_dispatcher_t::insert_documents(components::session::session_id_t& session, components::ql::ql_statement_t* statement) {
-        trace(log_, "manager_dispatcher_t::insert_documents session: {}, database: {}, collection name: {} ", session.data(), statement->database_, statement->collection_);
-        return actor_zeta::send(dispatcher(), address(), collection::handler_id(collection::route::insert_documents), session, std::move(statement), current_message()->sender());
     }
 
     void manager_dispatcher_t::delete_documents(components::session::session_id_t& session, components::ql::ql_statement_t* statement) {

--- a/services/dispatcher/dispatcher.cpp
+++ b/services/dispatcher/dispatcher.cpp
@@ -272,6 +272,7 @@ namespace services::dispatcher {
         if (!check_load_from_wal(session)) {
             actor_zeta::send(s.address(), dispatcher_t::address(), handler_id(route::execute_ql_finish), session, result);
             remove_session(session_to_address_, session);
+            result_storage_.erase(session);
         }
     }
 

--- a/services/dispatcher/dispatcher.hpp
+++ b/services/dispatcher/dispatcher.hpp
@@ -37,7 +37,7 @@ namespace services::dispatcher {
         void load(components::session::session_id_t &session, actor_zeta::address_t sender);
         void load_from_disk_result(components::session::session_id_t &session, const services::disk::result_load_t &result);
         void load_from_memory_resource_result(components::session::session_id_t &session, const components::result::result_t &result);
-        void load_from_wal_result(components::session::session_id_t &session, std::vector<services::wal::record_t> records);
+        void load_from_wal_result(components::session::session_id_t &session, std::vector<services::wal::record_t>& records);
         void execute_ql(components::session::session_id_t& session, components::ql::ql_statement_t* ql, actor_zeta::address_t address);
         void execute_ql_finish(components::session::session_id_t& session, const components::result::result_t& result);
         void delete_documents(components::session::session_id_t& session, components::ql::ql_statement_t* statement, actor_zeta::address_t address);

--- a/services/dispatcher/dispatcher.hpp
+++ b/services/dispatcher/dispatcher.hpp
@@ -37,12 +37,9 @@ namespace services::dispatcher {
         void load(components::session::session_id_t &session, actor_zeta::address_t sender);
         void load_from_disk_result(components::session::session_id_t &session, const services::disk::result_load_t &result);
         void load_from_memory_resource_result(components::session::session_id_t &session, const components::result::result_t &result);
-        void load_from_wal_result(components::session::session_id_t &session, std::vector<services::wal::record_t> &records);
+        void load_from_wal_result(components::session::session_id_t &session, std::vector<services::wal::record_t> records);
         void execute_ql(components::session::session_id_t& session, components::ql::ql_statement_t* ql, actor_zeta::address_t address);
         void execute_ql_finish(components::session::session_id_t& session, const components::result::result_t& result);
-        void drop_collection_finish_from_disk(components::session::session_id_t& session, std::string& collection_name);
-        void insert_documents(components::session::session_id_t& session, components::ql::ql_statement_t* statement, actor_zeta::address_t address);
-        void insert_finish(components::session::session_id_t& session, components::result::result_insert& result);
         void delete_documents(components::session::session_id_t& session, components::ql::ql_statement_t* statement, actor_zeta::address_t address);
         void delete_finish(components::session::session_id_t& session, components::result::result_delete& result);
         void update_documents(components::session::session_id_t& session, components::ql::ql_statement_t* statement, actor_zeta::address_t address);
@@ -67,6 +64,7 @@ namespace services::dispatcher {
         session_storage_t session_to_address_;
         std::unordered_map<components::session::session_id_t, std::unique_ptr<components::cursor::cursor_t>> cursor_;
         std::unordered_map<collection_full_name_t, actor_zeta::address_t, collection_name_hash> collection_address_book_;
+        std::unordered_map<components::session::session_id_t, components::result::result_t> result_storage_; // to be able return result from wal_success
         disk::result_load_t load_result_;
         components::session::session_id_t load_session_;
         services::wal::id_t last_wal_id_ {0};
@@ -74,6 +72,8 @@ namespace services::dispatcher {
 
         std::pair<components::logical_plan::node_ptr, components::ql::storage_parameters> create_logic_plan(
                 components::ql::ql_statement_t* statement);
+        // TODO figure out what to do with records
+        std::vector<services::wal::record_t> records_;
     };
 
     using dispatcher_ptr = std::unique_ptr<dispatcher_t>;
@@ -115,7 +115,6 @@ namespace services::dispatcher {
         void create(components::session::session_id_t& session, std::string& name);
         void load(components::session::session_id_t &session);
         void execute_ql(components::session::session_id_t& session, components::ql::ql_statement_t* ql);
-        void insert_documents(components::session::session_id_t& session, components::ql::ql_statement_t* statement);
         void delete_documents(components::session::session_id_t& session, components::ql::ql_statement_t* statement);
         void update_documents(components::session::session_id_t& session, components::ql::ql_statement_t* statement);
         void size(components::session::session_id_t& session, std::string& database_name, std::string& collection);

--- a/services/dispatcher/session.hpp
+++ b/services/dispatcher/session.hpp
@@ -25,6 +25,11 @@ public:
         return std::get<T>(data_);
     }
 
+    template <typename T>
+    bool is_type() const {
+        return std::holds_alternative<T>(data_);
+    }
+
     components::ql::statement_type type() const;
 
 private:
@@ -63,13 +68,21 @@ auto make_session(session_storage_t& storage, const session_key_t& session, Args
 
 inline auto find_session(session_storage_t& storage, components::session::session_id_t session) -> session_t& {
     auto it = storage.find(session_key_t{session, {}});
+    assert(it != std::end(storage) && "it != std::end(storage)");
     return  it ->second;
+}
+
+inline auto is_session_exist(session_storage_t& storage, components::session::session_id_t session) -> bool {
+    auto it = storage.find(session_key_t{session, {}});
+    return it != std::end(storage);
 }
 
 inline auto find_session(session_storage_t& storage, components::session::session_id_t session, const std::string& name) -> session_t& {
     auto it = storage.find(session_key_t{session, name});
+    assert(it != std::end(storage) && "it != std::end(session_storage)");
     return  it ->second;
 }
+
 
 inline auto remove_session(session_storage_t& storage, components::session::session_id_t session) -> void  {
     storage.erase(session_key_t{session, {}});

--- a/services/wal/manager_wal_replicate.cpp
+++ b/services/wal/manager_wal_replicate.cpp
@@ -88,12 +88,12 @@ namespace services::wal {
         actor_zeta::send(dispatchers_[0]->address(), address(), handler_id(route::drop_collection), session, current_message()->sender(), std::move(data));
     }
 
-    void manager_wal_replicate_t::insert_one(session_id_t& session, components::ql::insert_one_t data) {
+    void manager_wal_replicate_t::insert_one(session_id_t& session, components::ql::insert_one_t& data) {
         trace(log_, "manager_wal_replicate_t::insert_one");
         actor_zeta::send(dispatchers_[0]->address(), address(), handler_id(route::insert_one), session, current_message()->sender(), std::move(data));
     }
 
-    void manager_wal_replicate_t::insert_many(session_id_t& session, components::ql::insert_many_t data) {
+    void manager_wal_replicate_t::insert_many(session_id_t& session, components::ql::insert_many_t& data) {
         trace(log_, "manager_wal_replicate_t::insert_many");
         actor_zeta::send(dispatchers_[0]->address(), address(), handler_id(route::insert_many), session, current_message()->sender(), std::move(data));
     }

--- a/services/wal/manager_wal_replicate.cpp
+++ b/services/wal/manager_wal_replicate.cpp
@@ -88,12 +88,12 @@ namespace services::wal {
         actor_zeta::send(dispatchers_[0]->address(), address(), handler_id(route::drop_collection), session, current_message()->sender(), std::move(data));
     }
 
-    void manager_wal_replicate_t::insert_one(session_id_t& session, components::ql::insert_one_t& data) {
+    void manager_wal_replicate_t::insert_one(session_id_t& session, components::ql::insert_one_t data) {
         trace(log_, "manager_wal_replicate_t::insert_one");
         actor_zeta::send(dispatchers_[0]->address(), address(), handler_id(route::insert_one), session, current_message()->sender(), std::move(data));
     }
 
-    void manager_wal_replicate_t::insert_many(session_id_t& session, components::ql::insert_many_t& data) {
+    void manager_wal_replicate_t::insert_many(session_id_t& session, components::ql::insert_many_t data) {
         trace(log_, "manager_wal_replicate_t::insert_many");
         actor_zeta::send(dispatchers_[0]->address(), address(), handler_id(route::insert_many), session, current_message()->sender(), std::move(data));
     }
@@ -128,20 +128,21 @@ namespace services::wal {
         : base_manager_wal_replicate_t(mr, scheduler) {
         trace(log, "manager_wal_replicate_empty_t");
         using namespace components;
+        add_handler(handler_id(route::load), &manager_wal_replicate_empty_t::always_success<services::wal::id_t>);
+        add_handler(handler_id(route::create_database), &manager_wal_replicate_empty_t::always_success<ql::create_database_t&>);
+        add_handler(handler_id(route::drop_database), &manager_wal_replicate_empty_t::always_success<ql::drop_database_t&>);
+        add_handler(handler_id(route::create_collection), &manager_wal_replicate_empty_t::always_success<ql::create_collection_t&>);
+        add_handler(handler_id(route::drop_collection), &manager_wal_replicate_empty_t::always_success<ql::drop_collection_t&>);
+        add_handler(handler_id(route::insert_one), &manager_wal_replicate_empty_t::always_success<ql::insert_one_t&>);
+        add_handler(handler_id(route::insert_many), &manager_wal_replicate_empty_t::always_success<ql::insert_many_t&>);
+        add_handler(handler_id(route::delete_one), &manager_wal_replicate_empty_t::always_success<ql::delete_one_t&>);
+        add_handler(handler_id(route::delete_many), &manager_wal_replicate_empty_t::always_success<ql::delete_many_t&>);
+        add_handler(handler_id(route::update_one), &manager_wal_replicate_empty_t::always_success<ql::update_one_t&>);
+        add_handler(handler_id(route::update_many), &manager_wal_replicate_empty_t::always_success<ql::update_many_t&>);
+        add_handler(handler_id(route::create_index), &manager_wal_replicate_empty_t::always_success<ql::create_index_t&>);
+
         add_handler(handler_id(route::create), &manager_wal_replicate_empty_t::nothing<>);
-        add_handler(handler_id(route::load), &manager_wal_replicate_empty_t::nothing<session_id_t&, services::wal::id_t>);
-        add_handler(handler_id(route::create_database), &manager_wal_replicate_empty_t::nothing<session_id_t&, ql::create_database_t&>);
-        add_handler(handler_id(route::drop_database), &manager_wal_replicate_empty_t::nothing<session_id_t&, ql::drop_database_t&>);
-        add_handler(handler_id(route::create_collection), &manager_wal_replicate_empty_t::nothing<session_id_t&, ql::create_collection_t&>);
-        add_handler(handler_id(route::drop_collection), &manager_wal_replicate_empty_t::nothing<session_id_t&, ql::drop_collection_t&>);
-        add_handler(handler_id(route::insert_one), &manager_wal_replicate_empty_t::nothing<session_id_t&, ql::insert_one_t&>);
-        add_handler(handler_id(route::insert_many), &manager_wal_replicate_empty_t::nothing<session_id_t&, ql::insert_many_t&>);
-        add_handler(handler_id(route::delete_one), &manager_wal_replicate_empty_t::nothing<session_id_t&, ql::delete_one_t&>);
-        add_handler(handler_id(route::delete_many), &manager_wal_replicate_empty_t::nothing<session_id_t&, ql::delete_many_t&>);
-        add_handler(handler_id(route::update_one), &manager_wal_replicate_empty_t::nothing<session_id_t&, ql::update_one_t&>);
-        add_handler(handler_id(route::update_many), &manager_wal_replicate_empty_t::nothing<session_id_t&, ql::update_many_t&>);
         add_handler(core::handler_id(core::route::sync), &manager_wal_replicate_empty_t::nothing<address_pack&>);
-        add_handler(handler_id(route::create_index), &manager_wal_replicate_empty_t::nothing<session_id_t&, ql::create_index_t&>);
     }
 
 } //namespace services::wal

--- a/services/wal/manager_wal_replicate.hpp
+++ b/services/wal/manager_wal_replicate.hpp
@@ -13,6 +13,7 @@
 
 #include "base.hpp"
 #include "wal.hpp"
+#include "route.hpp"
 
 namespace services::wal {
 
@@ -55,8 +56,8 @@ namespace services::wal {
         void drop_database(session_id_t& session, components::ql::drop_database_t& data);
         void create_collection(session_id_t& session, components::ql::create_collection_t& data);
         void drop_collection(session_id_t& session, components::ql::drop_collection_t& data);
-        void insert_one(session_id_t& session, components::ql::insert_one_t& data);
-        void insert_many(session_id_t& session, components::ql::insert_many_t& data);
+        void insert_one(session_id_t& session, components::ql::insert_one_t data);
+        void insert_many(session_id_t& session, components::ql::insert_many_t data);
         void delete_one(session_id_t& session, components::ql::delete_one_t& data);
         void delete_many(session_id_t& session, components::ql::delete_many_t& data);
         void update_one(session_id_t& session, components::ql::update_one_t& data);
@@ -79,6 +80,11 @@ namespace services::wal {
 
     public:
         manager_wal_replicate_empty_t(actor_zeta::detail::pmr::memory_resource*, actor_zeta::scheduler_raw, log_t&);
+
+        template<class T>
+        auto always_success(session_id_t& session, T&&) -> void {
+            actor_zeta::send(current_message()->sender(), address(), services::wal::handler_id(services::wal::route::success), session, services::wal::id_t(0));
+        }
 
         template<class ...Args>
         auto nothing(Args&&...) -> void {}

--- a/services/wal/manager_wal_replicate.hpp
+++ b/services/wal/manager_wal_replicate.hpp
@@ -56,8 +56,8 @@ namespace services::wal {
         void drop_database(session_id_t& session, components::ql::drop_database_t& data);
         void create_collection(session_id_t& session, components::ql::create_collection_t& data);
         void drop_collection(session_id_t& session, components::ql::drop_collection_t& data);
-        void insert_one(session_id_t& session, components::ql::insert_one_t data);
-        void insert_many(session_id_t& session, components::ql::insert_many_t data);
+        void insert_one(session_id_t& session, components::ql::insert_one_t& data);
+        void insert_many(session_id_t& session, components::ql::insert_many_t& data);
         void delete_one(session_id_t& session, components::ql::delete_one_t& data);
         void delete_many(session_id_t& session, components::ql::delete_many_t& data);
         void update_one(session_id_t& session, components::ql::update_one_t& data);

--- a/services/wal/wal.cpp
+++ b/services/wal/wal.cpp
@@ -51,6 +51,7 @@ namespace services::wal {
 
     void wal_replicate_t::send_success(session_id_t& session, address_t& sender) {
         if (sender) {
+            trace(log_, "wal_replicate_t::send_success session {}", session.data());
             actor_zeta::send(sender, address(), handler_id(route::success), session, services::wal::id_t(id_));
         }
     }
@@ -136,13 +137,13 @@ namespace services::wal {
         send_success(session, sender);
     }
 
-    void wal_replicate_t::insert_one(session_id_t& session, address_t& sender, components::ql::insert_one_t& data) {
+    void wal_replicate_t::insert_one(session_id_t& session, address_t& sender, components::ql::insert_one_t data) {
         trace(log_, "wal_replicate_t::insert_one {}::{}, session: {}", data.database_, data.collection_, session.data());
         write_data_(data);
         send_success(session, sender);
     }
 
-    void wal_replicate_t::insert_many(session_id_t& session, address_t& sender, components::ql::insert_many_t& data) {
+    void wal_replicate_t::insert_many(session_id_t& session, address_t& sender, components::ql::insert_many_t data) {
         trace(log_, "wal_replicate_t::insert_many {}::{}, session: {}", data.database_, data.collection_, session.data());
         write_data_(data);
         send_success(session, sender);

--- a/services/wal/wal.cpp
+++ b/services/wal/wal.cpp
@@ -137,13 +137,13 @@ namespace services::wal {
         send_success(session, sender);
     }
 
-    void wal_replicate_t::insert_one(session_id_t& session, address_t& sender, components::ql::insert_one_t data) {
+    void wal_replicate_t::insert_one(session_id_t& session, address_t& sender, components::ql::insert_one_t& data) {
         trace(log_, "wal_replicate_t::insert_one {}::{}, session: {}", data.database_, data.collection_, session.data());
         write_data_(data);
         send_success(session, sender);
     }
 
-    void wal_replicate_t::insert_many(session_id_t& session, address_t& sender, components::ql::insert_many_t data) {
+    void wal_replicate_t::insert_many(session_id_t& session, address_t& sender, components::ql::insert_many_t& data) {
         trace(log_, "wal_replicate_t::insert_many {}::{}, session: {}", data.database_, data.collection_, session.data());
         write_data_(data);
         send_success(session, sender);

--- a/services/wal/wal.hpp
+++ b/services/wal/wal.hpp
@@ -29,8 +29,8 @@ namespace services::wal {
         void drop_database(session_id_t& session, address_t& sender, components::ql::drop_database_t& data);
         void create_collection(session_id_t& session, address_t& sender, components::ql::create_collection_t& data);
         void drop_collection(session_id_t& session, address_t& sender, components::ql::drop_collection_t& data);
-        void insert_one(session_id_t& session, address_t& sender, components::ql::insert_one_t& data);
-        void insert_many(session_id_t& session, address_t& sender, components::ql::insert_many_t& data);
+        void insert_one(session_id_t& session, address_t& sender, components::ql::insert_one_t data);
+        void insert_many(session_id_t& session, address_t& sender, components::ql::insert_many_t data);
         void delete_one(session_id_t& session, address_t& sender, components::ql::delete_one_t& data);
         void delete_many(session_id_t& session, address_t& sender, components::ql::delete_many_t& data);
         void update_one(session_id_t& session, address_t& sender, components::ql::update_one_t& data);

--- a/services/wal/wal.hpp
+++ b/services/wal/wal.hpp
@@ -29,8 +29,8 @@ namespace services::wal {
         void drop_database(session_id_t& session, address_t& sender, components::ql::drop_database_t& data);
         void create_collection(session_id_t& session, address_t& sender, components::ql::create_collection_t& data);
         void drop_collection(session_id_t& session, address_t& sender, components::ql::drop_collection_t& data);
-        void insert_one(session_id_t& session, address_t& sender, components::ql::insert_one_t data);
-        void insert_many(session_id_t& session, address_t& sender, components::ql::insert_many_t data);
+        void insert_one(session_id_t& session, address_t& sender, components::ql::insert_one_t& data);
+        void insert_many(session_id_t& session, address_t& sender, components::ql::insert_many_t& data);
         void delete_one(session_id_t& session, address_t& sender, components::ql::delete_one_t& data);
         void delete_many(session_id_t& session, address_t& sender, components::ql::delete_many_t& data);
         void update_one(session_id_t& session, address_t& sender, components::ql::update_one_t& data);


### PR DESCRIPTION
Main task [Insert, delete and update should be part of execute_ql](https://github.com/duckstax/ottergon/issues/271)

* Now insert_one and insert_many are part of the execute_ql
* Now we have to wait on wal response for all mutable operations
* For update and delete we don't wait (will be fixed soon)
* Now when wal is off we correctly process on empty manager_wal_replicate
* Remove waiting signal from disk on remove collection