### PR TITLE
refactoring: Move delete and update to execute ql

### DIFF
--- a/integration/cpp/wrapper_dispatcher.hpp
+++ b/integration/cpp/wrapper_dispatcher.hpp
@@ -38,10 +38,10 @@ namespace otterbrix {
         [[deprecated]] auto insert_many(session_id_t &session, const database_name_t &database, const collection_name_t &collection, std::pmr::vector<document_ptr> &documents) -> components::result::result_t&;
         [[deprecated]] auto find(session_id_t &session, components::ql::aggregate_statement_raw_ptr condition) -> components::result::result_t;
         [[deprecated]] auto find_one(session_id_t &session, components::ql::aggregate_statement_raw_ptr condition) -> components::result::result_t;
-        [[deprecated]] auto delete_one(session_id_t &session, components::ql::aggregate_statement_raw_ptr condition) -> components::result::result_delete&;
-        [[deprecated]] auto delete_many(session_id_t &session, components::ql::aggregate_statement_raw_ptr condition) -> components::result::result_delete&;
-        [[deprecated]] auto update_one(session_id_t &session, components::ql::aggregate_statement_raw_ptr condition, document_ptr update, bool upsert) -> components::result::result_update&;
-        [[deprecated]] auto update_many(session_id_t &session, components::ql::aggregate_statement_raw_ptr condition, document_ptr update, bool upsert) -> components::result::result_update&;
+        [[deprecated]] auto delete_one(session_id_t &session, components::ql::aggregate_statement_raw_ptr condition) -> components::result::result_t&;
+        [[deprecated]] auto delete_many(session_id_t &session, components::ql::aggregate_statement_raw_ptr condition) -> components::result::result_t&;
+        [[deprecated]] auto update_one(session_id_t &session, components::ql::aggregate_statement_raw_ptr condition, document_ptr update, bool upsert) -> components::result::result_t&;
+        [[deprecated]] auto update_many(session_id_t &session, components::ql::aggregate_statement_raw_ptr condition, document_ptr update, bool upsert) -> components::result::result_t&;
         [[deprecated]] auto size(session_id_t &session, const database_name_t &database, const collection_name_t &collection) -> components::result::result_size;
         auto create_index(session_id_t &session, components::ql::create_index_t index) -> components::result::result_create_index;
         auto drop_index(session_id_t &session, components::ql::drop_index_t drop_index) -> components::result::result_drop_index;

--- a/integration/python/wrapper_collection.cpp
+++ b/integration/python/wrapper_collection.cpp
@@ -115,7 +115,15 @@ namespace otterbrix {
             auto update = to_document(fields);
             generate_document_id_if_not_exists(update);
             auto session_tmp = otterbrix::session_id_t();
-            auto result = ptr_->update_one(session_tmp, statement.release(), std::move(update), upsert);
+
+            auto result_variant = ptr_->update_one(session_tmp, statement.release(), std::move(update), upsert);
+            if(result_variant.is_error()){
+                debug(log_, "wrapper_collection::update_one has result error while update");
+                throw std::runtime_error("wrapper_collection::update_one error_result");
+            }
+            assert(result_variant.is_type<components::result::result_update>() && "wrapper_collection::update_one result error");
+            auto& result = result_variant.get<components::result::result_update>();
+
             debug(log_, "wrapper_collection::update_one {} modified {} no modified upsert id {}", result.modified_ids().size(), result.nomodified_ids().size(), result.upserted_id().to_string());
             return wrapper_result_update(result);
         }
@@ -130,7 +138,15 @@ namespace otterbrix {
             auto update = to_document(fields);
             generate_document_id_if_not_exists(update);
             auto session_tmp = otterbrix::session_id_t();
-            auto result = ptr_->update_many(session_tmp, statement.release(), std::move(update), upsert);
+
+            auto result_variant = ptr_->update_many(session_tmp, statement.release(), std::move(update), upsert);
+            if(result_variant.is_error()){
+                debug(log_, "wrapper_collection::update_many has result error while update");
+                throw std::runtime_error("wrapper_collection::update_many error_result");
+            }
+            assert(result_variant.is_type<components::result::result_update>() && "wrapper_collection::update_many result error");
+            auto& result = result_variant.get<components::result::result_update>();
+
             debug(log_, "wrapper_collection::update_many {} modified {} no modified upsert id {}", result.modified_ids().size(), result.nomodified_ids().size(), result.upserted_id().to_string());
             return wrapper_result_update(result);
         }
@@ -175,7 +191,15 @@ namespace otterbrix {
             auto statement = components::ql::make_aggregate_statement(database_, name_);
             to_statement(pack_to_match(cond), statement.get());
             auto session_tmp = otterbrix::session_id_t();
-            auto result = ptr_->delete_one(session_tmp, statement.release());
+
+            auto result_variant = ptr_->delete_one(session_tmp, statement.release());
+            if(result_variant.is_error()){
+                debug(log_, "wrapper_collection::delete_one has result error while delete");
+                throw std::runtime_error("wrapper_collection::delete_one error_result");
+            }
+            assert(result_variant.is_type<components::result::result_delete>() && "wrapper_collection::delete_one result error");
+            auto& result = result_variant.get<components::result::result_delete>();
+
             debug(log_, "wrapper_collection::delete_one {} deleted", result.deleted_ids().size());
             return wrapper_result_delete(result);
         }
@@ -188,7 +212,15 @@ namespace otterbrix {
             auto statement = components::ql::make_aggregate_statement(database_, name_);
             to_statement(pack_to_match(cond), statement.get());
             auto session_tmp = otterbrix::session_id_t();
-            auto result = ptr_->delete_many(session_tmp, statement.release());
+
+            auto result_variant = ptr_->delete_many(session_tmp, statement.release());
+            if(result_variant.is_error()){
+                debug(log_, "wrapper_collection::delete_many has result error while delete");
+                throw std::runtime_error("wrapper_collection::delete_many error_result");
+            }
+            assert(result_variant.is_type<components::result::result_delete>() && "wrapper_collection::delete_many result error");
+            auto& result = result_variant.get<components::result::result_delete>();
+
             debug(log_, "wrapper_collection::delete_many {} deleted", result.deleted_ids().size());
             return wrapper_result_delete(result);
         }

--- a/services/collection/collection.hpp
+++ b/services/collection/collection.hpp
@@ -94,16 +94,6 @@ namespace services::collection {
                 const components::logical_plan::node_ptr& logical_plan,
                 components::ql::storage_parameters parameters) -> void;
 
-        auto delete_documents(
-                const components::session::session_id_t& session,
-                const components::logical_plan::node_ptr& logic_plan,
-                components::ql::storage_parameters parameters) -> void;
-
-        auto update_documents(
-                const components::session::session_id_t& session,
-                const components::logical_plan::node_ptr& logic_plan,
-                components::ql::storage_parameters parameters) -> void;
-
         void drop(const session_id_t& session);
         void close_cursor(session_id_t& session);
 
@@ -118,6 +108,15 @@ namespace services::collection {
         context_collection_t* extract();
 
     private:
+        void find_document_impl(const components::session::session_id_t& session, const actor_zeta::address_t& sender,
+                                        operators::operator_ptr plan);
+        void update_document_impl(const components::session::session_id_t& session, const actor_zeta::address_t& sender,
+                                        operators::operator_ptr plan);
+        void insert_document_impl(const components::session::session_id_t& session, const actor_zeta::address_t& sender,
+                                        operators::operator_ptr plan);
+        void delete_document_impl(const components::session::session_id_t& session, const actor_zeta::address_t& sender,
+                                        operators::operator_ptr plan);
+
         std::size_t size_() const;
         bool drop_();
 

--- a/services/collection/route.hpp
+++ b/services/collection/route.hpp
@@ -7,18 +7,13 @@ namespace services::collection {
     enum class route : uint64_t {
         create_documents,
         execute_plan,
-        delete_documents,
-        update_documents,
         size,
         close_cursor,
         drop_collection,
         create_index,
         drop_index,
-
         create_documents_finish,
         execute_plan_finish,
-        delete_finish,
-        update_finish,
         size_finish,
         drop_collection_finish,
         create_index_finish,

--- a/services/dispatcher/dispatcher.hpp
+++ b/services/dispatcher/dispatcher.hpp
@@ -40,10 +40,6 @@ namespace services::dispatcher {
         void load_from_wal_result(components::session::session_id_t &session, std::vector<services::wal::record_t>& records);
         void execute_ql(components::session::session_id_t& session, components::ql::ql_statement_t* ql, actor_zeta::address_t address);
         void execute_ql_finish(components::session::session_id_t& session, const components::result::result_t& result);
-        void delete_documents(components::session::session_id_t& session, components::ql::ql_statement_t* statement, actor_zeta::address_t address);
-        void delete_finish(components::session::session_id_t& session, components::result::result_delete& result);
-        void update_documents(components::session::session_id_t& session, components::ql::ql_statement_t* statement, actor_zeta::address_t address);
-        void update_finish(components::session::session_id_t& session, components::result::result_update& result);
         void size(components::session::session_id_t& session, std::string& database_name, std::string& collection, actor_zeta::address_t address);
         void size_finish(components::session::session_id_t&, components::result::result_size& result);
         void create_index(components::session::session_id_t &session, components::ql::create_index_t index, actor_zeta::address_t address);
@@ -115,8 +111,6 @@ namespace services::dispatcher {
         void create(components::session::session_id_t& session, std::string& name);
         void load(components::session::session_id_t &session);
         void execute_ql(components::session::session_id_t& session, components::ql::ql_statement_t* ql);
-        void delete_documents(components::session::session_id_t& session, components::ql::ql_statement_t* statement);
-        void update_documents(components::session::session_id_t& session, components::ql::ql_statement_t* statement);
         void size(components::session::session_id_t& session, std::string& database_name, std::string& collection);
         void close_cursor(components::session::session_id_t& session);
         void create_index(components::session::session_id_t& session, components::ql::create_index_t index);


### PR DESCRIPTION
Previous [PR](https://github.com/duckstax/otterbrix/pull/259)

Summary: delete documents and update documents now work through the execute_ql

Related task: [Insert, delete and update should be part of execute_q](https://github.com/duckstax/ottergon/issues/271)