### PR TITLE
[refactoring] remove find_sessoin with name

### DIFF
--- a/components/session/session.cpp
+++ b/components/session/session.cpp
@@ -29,4 +29,6 @@ namespace components::session {
         counter_ = static_cast<uint64_t>(uniq_counter);
         data_ = static_cast<uint64_t>(std::time(nullptr)); //todo recanting
     }
+
+    session_id_t session_id_t::generate_uid() { return session_id_t{}; }
 } // namespace components::session

--- a/components/session/session.hpp
+++ b/components/session/session.hpp
@@ -14,6 +14,13 @@ namespace components::session {
         bool operator<(const session_id_t& other) const;
         auto data() const -> std::uint64_t;
 
+        /**
+         * @brief Generate new unique session id
+         *
+         * @return session_id_t new unique id
+         */
+        static session_id_t generate_uid();
+
     private:
         std::uint64_t data_;
         std::uint64_t counter_;

--- a/services/collection/create_index.cpp
+++ b/services/collection/create_index.cpp
@@ -27,6 +27,8 @@ namespace services::collection {
                 return "hashed";
             case index_type::wildcard:
                 return "wildcard";
+            case index_type::no_valid:
+                return "no_valid";
         }
         return "default";
     }
@@ -67,19 +69,15 @@ namespace services::collection {
                     break;
                 }
 
-                case index_type::composite: {
-                    break;
-                }
-
-                case index_type::multikey: {
-                    break;
-                }
-
-                case index_type::hashed: {
-                    break;
-                }
-
+                case index_type::composite:
+                case index_type::multikey:
+                case index_type::hashed:
                 case index_type::wildcard: {
+                    assert(false && "index_type not implemented");
+                    break;
+                }
+                case index_type::no_valid: {
+                    assert(false && "index_type not valid");
                     break;
                 }
             }
@@ -97,7 +95,6 @@ namespace services::collection {
                          address(),
                          handler_id(route::create_index_finish),
                          session,
-                         name,
                          make_cursor(default_resource(), operation_status_t::success));
         sessions::remove(sessions_, session, name);
     }
@@ -109,7 +106,6 @@ namespace services::collection {
                              address(),
                              handler_id(route::drop_index_finish),
                              session,
-                             index.name(),
                              make_cursor(default_resource(), error_code_t::collection_dropped));
         } else {
             auto index_ptr = components::index::search_index(context_->index_engine(), index.name());
@@ -122,14 +118,12 @@ namespace services::collection {
                                  address(),
                                  handler_id(route::drop_index_finish),
                                  session,
-                                 index.name(),
                                  make_cursor(default_resource(), operation_status_t::success));
             } else {
                 actor_zeta::send(current_message()->sender(),
                                  address(),
                                  handler_id(route::drop_index_finish),
                                  session,
-                                 index.name(),
                                  make_cursor(default_resource(), error_code_t::collection_not_exists));
             }
         }

--- a/services/disk/manager_disk.cpp
+++ b/services/disk/manager_disk.cpp
@@ -257,10 +257,13 @@ namespace services::disk {
         auto indexes = read_indexes_();
         metafile_indexes_->seek_eof();
         for (const auto& index : indexes) {
+            trace(log_, "manager_disk: load_indexes_ : {}", index.name());
+            // Require to separate sessions for load and create index
+            // For each index create we need to generate unique session id.
             actor_zeta::send(dispatcher,
                              address(),
                              collection::handler_id(collection::route::create_index),
-                             session,
+                             session_id_t::generate_uid(),
                              index,
                              dispatcher);
         }

--- a/services/dispatcher/dispatcher.hpp
+++ b/services/dispatcher/dispatcher.hpp
@@ -60,28 +60,27 @@ namespace services::dispatcher {
         void create_index(components::session::session_id_t& session,
                           components::ql::create_index_t index,
                           actor_zeta::address_t address);
-        void create_index_finish(components::session::session_id_t& session,
-                                 const std::string& name,
-                                 components::cursor::cursor_t_ptr cursor);
+        void create_index_finish(components::session::session_id_t& session, components::cursor::cursor_t_ptr cursor);
+
         void drop_index(components::session::session_id_t& session,
                         components::ql::drop_index_t drop_index,
                         actor_zeta::address_t address);
-        void drop_index_finish(components::session::session_id_t& session,
-                               const std::string& name,
-                               components::cursor::cursor_t_ptr cursor);
+
+        void drop_index_finish(components::session::session_id_t& session, components::cursor::cursor_t_ptr cursor);
+
         void close_cursor(components::session::session_id_t& session);
         void wal_success(components::session::session_id_t& session, services::wal::id_t wal_id);
         bool check_load_from_wal(components::session::session_id_t& session);
 
     private:
         log_t log_;
-        std::pmr::memory_resource* resource_;
         actor_zeta::address_t manager_dispatcher_;
+        std::pmr::memory_resource* resource_;
+        std::unordered_map<components::session::session_id_t, actor_zeta::address_t> last_collection_;
         actor_zeta::address_t memory_storage_;
         actor_zeta::address_t manager_wal_;
         actor_zeta::address_t manager_disk_;
         session_storage_t session_to_address_;
-        std::unordered_map<components::session::session_id_t, actor_zeta::address_t> last_collection_;
         std::unordered_map<components::session::session_id_t, std::unique_ptr<components::cursor::cursor_t>> cursor_;
         std::unordered_map<collection_full_name_t, actor_zeta::address_t, collection_name_hash>
             collection_address_book_;

--- a/services/dispatcher/session.hpp
+++ b/services/dispatcher/session.hpp
@@ -36,14 +36,13 @@ private:
     ///components::session::session_id_t session_;
 };
 
+// TODO Remove this session and use logic from collections
+// Move session logic from collections to a separate place
 struct session_key_t {
     components::session::session_id_t id;
-    std::string name;
 };
 
-inline bool operator==(const session_key_t& key1, const session_key_t& key2) {
-    return key1.id == key2.id && key1.name == key2.name;
-}
+inline bool operator==(const session_key_t& key1, const session_key_t& key2) { return key1.id == key2.id; }
 
 struct session_key_hash {
     std::size_t operator()(const session_key_t& key) const {
@@ -55,7 +54,7 @@ using session_storage_t = std::unordered_map<session_key_t, session_t, session_k
 
 template<class... Args>
 auto make_session(session_storage_t& storage, components::session::session_id_t session, Args&&... args) -> void {
-    storage.emplace(session_key_t{session, {}}, session_t(std::forward<Args>(args)...));
+    storage.emplace(session_key_t{session}, session_t(std::forward<Args>(args)...));
 }
 
 template<class... Args>
@@ -64,28 +63,16 @@ auto make_session(session_storage_t& storage, const session_key_t& session, Args
 }
 
 inline auto find_session(session_storage_t& storage, components::session::session_id_t session) -> session_t& {
-    auto it = storage.find(session_key_t{session, {}});
+    auto it = storage.find(session_key_t{session});
     assert(it != std::end(storage) && "it != std::end(storage)");
     return it->second;
 }
 
 inline auto is_session_exist(session_storage_t& storage, components::session::session_id_t session) -> bool {
-    auto it = storage.find(session_key_t{session, {}});
+    auto it = storage.find(session_key_t{session});
     return it != std::end(storage);
 }
 
-inline auto find_session(session_storage_t& storage, components::session::session_id_t session, const std::string& name)
-    -> session_t& {
-    auto it = storage.find(session_key_t{session, name});
-    assert(it != std::end(storage) && "it != std::end(session_storage)");
-    return it->second;
-}
-
 inline auto remove_session(session_storage_t& storage, components::session::session_id_t session) -> void {
-    storage.erase(session_key_t{session, {}});
-}
-
-inline auto
-remove_session(session_storage_t& storage, components::session::session_id_t session, const std::string& name) -> void {
-    storage.erase(session_key_t{session, name});
+    storage.erase(session_key_t{session});
 }


### PR DESCRIPTION
Removing string name field from session_key in dispatcher session. 
Because of further refactoring require remove name usage in create/drop_index  from dispatcher -> require session changes.