### PR TITLE
322 implement sql like index parser internals

### DIFF
--- a/components/cursor/cursor.hpp
+++ b/components/cursor/cursor.hpp
@@ -33,7 +33,7 @@ namespace components::cursor {
         database_not_exists = 2,
         collection_already_exists = 3,
         collection_not_exists = 4,
-        index_already_exist = 5,
+        index_create_fail = 5,
         collection_dropped = 6,
         sql_parse_error = 7,
         create_phisical_plan_error = 8

--- a/components/document/core/value.cpp
+++ b/components/document/core/value.cpp
@@ -19,15 +19,27 @@ namespace document::impl {
 
     using namespace internal;
 
-    static const value_type value_types[] = {value_type::number,
-                                             value_type::number,
-                                             value_type::number,
-                                             value_type::null,
-                                             value_type::string,
-                                             value_type::data,
-                                             value_type::array,
-                                             value_type::dict,
-                                             value_type::null};
+    namespace {
+        static const value_type value_types[] = {value_type::number,
+                                                 value_type::number,
+                                                 value_type::number,
+                                                 value_type::null,
+                                                 value_type::string,
+                                                 value_type::data,
+                                                 value_type::array,
+                                                 value_type::dict,
+                                                 value_type::null};
+
+        static const core::type schema_types[] = {core::type::int64,
+                                                  core::type::int64,
+                                                  core::type::float64,
+                                                  core::type::undef,
+                                                  core::type::str,
+                                                  core::type::undef,
+                                                  core::type::undef,
+                                                  core::type::undef,
+                                                  core::type::undef};
+    } // namespace
 
     class const_value_t : public value_t {
     public:
@@ -57,8 +69,29 @@ namespace document::impl {
                 default:
                     return value_type::null;
             }
-        } else {
-            return value_types[t];
+        }
+        return value_types[t];
+    }
+
+    core::type value_t::schema_type() const noexcept {
+        auto t = tag();
+        if (_usually_false(t == tag_special)) {
+            switch (tiny_value()) {
+                case special_value_false:
+                case special_value_true:
+                    return core::type::bool8;
+                case special_value_undefined:
+                    return core::type::undef;
+                case special_value_null:
+                default:
+                    return core::type::undef;
+            }
+        }
+        switch (t) {
+            case tag_int:
+                return (byte_[0] & 0x08) != 0 ? core::type::uint64 : core::type::int64;
+            default:
+                return schema_types[t];
         }
     }
 

--- a/components/document/core/value.hpp
+++ b/components/document/core/value.hpp
@@ -7,6 +7,7 @@
 #include <components/document/support/endian.hpp>
 #include <components/document/support/exception.hpp>
 #include <components/document/support/ref_counted.hpp>
+#include <core/types.hpp>
 
 namespace document::impl {
 
@@ -46,6 +47,7 @@ namespace document::impl {
         static const value_t* const undefined_value;
 
         value_type type() const noexcept PURE;
+        core::type schema_type() const noexcept PURE;
         bool is_equal(const value_t*) const PURE;
         bool is_lt(const value_t*) const PURE;
         bool is_lte(const value_t*) const PURE;

--- a/components/document/document.cpp
+++ b/components/document/document.cpp
@@ -175,6 +175,22 @@ namespace components::document {
         set_new_value_(value_, key, value);
     }
 
+    core::type document_t::type_by_key(const std::string& key) const {
+        const auto value = get_value_by_key_(value_, key);
+        if (value == nullptr) {
+            return core::type::undef;
+        }
+        return value->schema_type();
+    }
+
+    core::type document_t::type_by_key(std::string_view key) const {
+        const auto value = get_value_by_key_(value_, key);
+        if (value == nullptr) {
+            return core::type::undef;
+        }
+        return value->schema_type();
+    }
+
     document_ptr combine_documents(const document_ptr& left, const document_ptr& right) {
         auto combined_doc = make_document();
         document_view_t combined_doc_view(combined_doc);

--- a/components/document/document.hpp
+++ b/components/document/document.hpp
@@ -28,6 +28,9 @@ namespace components::document {
         template<class T>
         void set(const std::string& key, T value);
 
+        core::type type_by_key(const std::string& key) const;
+        core::type type_by_key(std::string_view key) const;
+
         bool update(const ptr& update);
 
     private:

--- a/components/document/document_view.cpp
+++ b/components/document/document_view.cpp
@@ -24,6 +24,10 @@ namespace components::document {
 
     document_ptr document_view_t::get_ptr() const { return document_; }
 
+    core::type document_view_t::type_by_key(const std::string& key) const { return document_->type_by_key(key); }
+
+    core::type document_view_t::type_by_key(std::string_view key) const { return document_->type_by_key(key); }
+
     bool document_view_t::is_valid() const { return document_ != nullptr; }
 
     bool document_view_t::is_dict() const { return document_->value_->type() == value_type::dict; }

--- a/components/document/document_view.hpp
+++ b/components/document/document_view.hpp
@@ -24,6 +24,9 @@ namespace components::document {
         document_id_t id() const;
         document_ptr get_ptr() const;
 
+        core::type type_by_key(const std::string& key) const;
+        core::type type_by_key(std::string_view key) const;
+
         bool is_valid() const;
         bool is_dict() const;
         bool is_array() const;

--- a/components/expressions/key.hpp
+++ b/components/expressions/key.hpp
@@ -12,6 +12,13 @@ namespace components::expressions {
             : type_(type::non)
             , storage_({}) {}
 
+        key_t(key_t&& key)
+            : type_{key.type_}
+            , storage_{std::move(key.storage_)} {}
+
+        key_t(const key_t& key) = default;
+        key_t& operator=(const key_t& key) = default;
+
         explicit key_t(std::string_view str)
             : type_(type::string)
             , storage_(std::string(str.data(), str.size())) {}

--- a/components/logical_plan/node_create_index.cpp
+++ b/components/logical_plan/node_create_index.cpp
@@ -19,8 +19,7 @@ namespace components::logical_plan {
         for (const auto& key : ql_->keys_) {
             stream << key.as_string() << ' ';
         }
-        stream << "] type:" << name_index_type(ql_->index_type_)
-               << "compare: " << name_index_compare(ql_->index_compare_);
+        stream << "] type:" << name_index_type(ql_->index_type_) << "compare: " << type_name(ql_->index_compare_);
         return stream.str();
     }
 

--- a/components/pipeline/context.cpp
+++ b/components/pipeline/context.cpp
@@ -5,6 +5,12 @@ namespace components::pipeline {
     context_t::context_t(ql::storage_parameters init_parameters)
         : parameters(std::move(init_parameters)) {}
 
+    context_t::context_t(context_t&& context)
+        : session(context.session)
+        , current_message_sender(std::move(context.current_message_sender))
+        , parameters(std::move(context.parameters))
+        , address_(std::move(context.address_)) {}
+
     context_t::context_t(session::session_id_t session,
                          actor_zeta::address_t address,
                          actor_zeta::address_t sender,

--- a/components/pipeline/context.hpp
+++ b/components/pipeline/context.hpp
@@ -13,6 +13,7 @@ namespace components::pipeline {
         ql::storage_parameters parameters;
 
         explicit context_t(ql::storage_parameters init_parameters);
+        context_t(context_t&& context);
         context_t(session::session_id_t session,
                   actor_zeta::address_t address,
                   actor_zeta::address_t sender,

--- a/components/ql/index.hpp
+++ b/components/ql/index.hpp
@@ -2,6 +2,7 @@
 
 #include "ql_statement.hpp"
 #include <components/expressions/key.hpp>
+#include <core/types.hpp>
 #include <memory_resource>
 #include <msgpack.hpp>
 #include <vector>
@@ -38,61 +39,12 @@ namespace components::ql {
         return "default";
     }
 
-    enum class index_compare
-    {
-        undef,
-        str,
-        int8,
-        int16,
-        int32,
-        int64,
-        uint8,
-        uint16,
-        uint32,
-        uint64,
-        float32,
-        float64,
-        bool8
-    };
-
-    inline std::string name_index_compare(index_compare type) {
-        switch (type) {
-            case index_compare::undef:
-                return "undef";
-            case index_compare::str:
-                return "srt";
-            case index_compare::int8:
-                return "int8";
-            case index_compare::int16:
-                return "int16";
-            case index_compare::int32:
-                return "int32";
-            case index_compare::int64:
-                return "int64";
-            case index_compare::uint8:
-                return "uint8";
-            case index_compare::uint16:
-                return "uint16";
-            case index_compare::uint32:
-                return "uint32";
-            case index_compare::uint64:
-                return "uint64";
-            case index_compare::float32:
-                return "float32";
-            case index_compare::float64:
-                return "float64";
-            case index_compare::bool8:
-                return "bool8";
-        }
-        return "invalid";
-    }
-
     struct create_index_t final : ql_statement_t {
         create_index_t(const database_name_t& database,
                        const collection_name_t& collection,
                        const std::string& name,
                        index_type type,
-                       index_compare index_compare)
+                       core::type index_compare)
             : ql_statement_t(statement_type::create_index, database, collection)
             , name_{name}
             , index_type_(type)
@@ -105,12 +57,12 @@ namespace components::ql {
             : ql_statement_t(statement_type::create_index, database, collection)
             , name_{name}
             , index_type_(type)
-            , index_compare_(index_compare::undef) {}
+            , index_compare_(core::type::undef) {}
 
         create_index_t()
             : ql_statement_t(statement_type::create_index, {}, {})
             , index_type_(index_type::no_valid)
-            , index_compare_(index_compare::str) {}
+            , index_compare_(core::type::str) {}
 
         create_index_t(const create_index_t&) = default;
         create_index_t& operator=(const create_index_t&) = default;
@@ -128,7 +80,7 @@ namespace components::ql {
         std::string name_ = {"unnamed"};
         keys_base_storage_t keys_;
         index_type index_type_;
-        index_compare index_compare_;
+        core::type index_compare_;
     };
 
     struct drop_index_t final : ql_statement_t {
@@ -150,6 +102,8 @@ namespace components::ql {
         std::string name_;
     };
 
+    using create_index_ptr = std::unique_ptr<create_index_t>;
+
 } // namespace components::ql
 
 // User defined class template specialization
@@ -169,7 +123,7 @@ namespace msgpack {
                     v.collection_ = o.via.array.ptr[1].as<std::string>();
                     v.name_ = o.via.array.ptr[2].as<std::string>();
                     v.index_type_ = static_cast<components::ql::index_type>(o.via.array.ptr[3].as<uint8_t>());
-                    v.index_compare_ = static_cast<components::ql::index_compare>(o.via.array.ptr[4].as<uint8_t>());
+                    v.index_compare_ = static_cast<core::type>(o.via.array.ptr[4].as<uint8_t>());
                     auto data = o.via.array.ptr[5].as<std::vector<std::string>>();
                     v.keys_ = components::ql::keys_base_storage_t(data.begin(), data.end());
                     return o;

--- a/components/sql/parser/base/parser_mask.cpp
+++ b/components/sql/parser/base/parser_mask.cpp
@@ -129,6 +129,7 @@ namespace components::sql::impl {
             if (is_integer(token.value())) {
                 return ::document::wrapper_value_t(std::atol(token.value().data()));
             } else {
+                // TODO we don't support float in this case?
                 return ::document::wrapper_value_t(std::atof(token.value().data()));
             }
         } else if (is_token_bool_value_true(token)) {

--- a/components/sql/test/test_index_parser.cpp
+++ b/components/sql/test/test_index_parser.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch.hpp>
 #include <components/ql/index.hpp>
 #include <components/sql/parser.hpp>
+#include <core/types.hpp>
 
 using namespace components;
 
@@ -15,7 +16,7 @@ TEST_CASE("parser::create_index") {
         REQUIRE(std::get<ql::create_index_t>(ql).keys_.size() == 1);
         REQUIRE(std::get<ql::create_index_t>(ql).name() == "TEST_COLLECTION_base");
         REQUIRE(std::get<ql::create_index_t>(ql).index_type_ == ql::index_type::single);
-        REQUIRE(std::get<ql::create_index_t>(ql).index_compare_ == ql::index_compare::undef);
+        REQUIRE(std::get<ql::create_index_t>(ql).index_compare_ == core::type::undef);
     }
 
     SECTION("unsupported multi index") {

--- a/core/types.hpp
+++ b/core/types.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <string>
+
+namespace core {
+    enum class type
+    {
+        undef,
+        str,
+        int8,
+        int16,
+        int32,
+        int64,
+        uint8,
+        uint16,
+        uint32,
+        uint64,
+        float32,
+        float64,
+        bool8
+    };
+
+    inline std::string type_name(type type) noexcept {
+        switch (type) {
+            case type::undef:
+                return "undef";
+            case type::str:
+                return "srt";
+            case type::int8:
+                return "int8";
+            case type::int16:
+                return "int16";
+            case type::int32:
+                return "int32";
+            case type::int64:
+                return "int64";
+            case type::uint8:
+                return "uint8";
+            case type::uint16:
+                return "uint16";
+            case type::uint32:
+                return "uint32";
+            case type::uint64:
+                return "uint64";
+            case type::float32:
+                return "float32";
+            case type::float64:
+                return "float64";
+            case type::bool8:
+                return "bool8";
+        }
+        return "invalid";
+    }
+} // namespace core

--- a/integration/cpp/test/test_index.cpp
+++ b/integration/cpp/test/test_index.cpp
@@ -73,7 +73,7 @@ constexpr int kDocuments = 100;
         ql.keys_.emplace_back(KEY);                                                                                    \
         auto res = dispatcher->create_index(session, &ql);                                                             \
         REQUIRE(res->is_error() == true);                                                                              \
-        REQUIRE(res->get_error().type == components::cursor::error_code_t::index_already_exist);                       \
+        REQUIRE(res->get_error().type == components::cursor::error_code_t::index_create_fail);                         \
                                                                                                                        \
     } while (false)
 
@@ -122,7 +122,7 @@ TEST_CASE("integration::test_index::base") {
 
     INFO("initialization") {
         INIT_COLLECTION();
-        CREATE_INDEX("ncount", components::ql::index_compare::int64, "count");
+        CREATE_INDEX("ncount", core::type::int64, "count");
         FILL_COLLECTION();
     }
 
@@ -146,9 +146,9 @@ TEST_CASE("integration::test_index::save_load") {
         auto* dispatcher = space.dispatcher();
 
         INIT_COLLECTION();
-        CREATE_INDEX("ncount", components::ql::index_compare::int64, "count");
-        CREATE_INDEX("scount", components::ql::index_compare::str, "countStr");
-        CREATE_INDEX("dcount", components::ql::index_compare::float64, "countDouble");
+        CREATE_INDEX("ncount", core::type::int64, "count");
+        CREATE_INDEX("scount", core::type::str, "countStr");
+        CREATE_INDEX("dcount", core::type::float64, "countDouble");
         FILL_COLLECTION();
     }
 
@@ -175,9 +175,9 @@ TEST_CASE("integration::test_index::drop") {
 
     INFO("initialization") {
         INIT_COLLECTION();
-        CREATE_INDEX("ncount", components::ql::index_compare::int64, "count");
-        CREATE_INDEX("scount", components::ql::index_compare::str, "countStr");
-        CREATE_INDEX("dcount", components::ql::index_compare::float64, "countDouble");
+        CREATE_INDEX("ncount", core::type::int64, "count");
+        CREATE_INDEX("scount", core::type::str, "countStr");
+        CREATE_INDEX("dcount", core::type::float64, "countDouble");
         FILL_COLLECTION();
         usleep(1000000); //todo: wait
     }
@@ -225,25 +225,25 @@ TEST_CASE("integration::test_index::index already exist") {
 
     INFO("initialization") {
         INIT_COLLECTION();
-        CREATE_INDEX("ncount", components::ql::index_compare::int64, "count");
-        CREATE_INDEX("scount", components::ql::index_compare::str, "countStr");
-        CREATE_INDEX("dcount", components::ql::index_compare::float64, "countDouble");
+        CREATE_INDEX("ncount", core::type::int64, "count");
+        CREATE_INDEX("scount", core::type::str, "countStr");
+        CREATE_INDEX("dcount", core::type::float64, "countDouble");
         FILL_COLLECTION();
     }
 
     INFO("add existed ncount index") {
-        CREATE_EXISTED_INDEX("ncount", components::ql::index_compare::int64, "count");
-        CREATE_EXISTED_INDEX("ncount", components::ql::index_compare::int64, "count");
+        CREATE_EXISTED_INDEX("ncount", core::type::int64, "count");
+        CREATE_EXISTED_INDEX("ncount", core::type::int64, "count");
     }
 
     INFO("add existed scount index") {
-        CREATE_INDEX("scount", components::ql::index_compare::str, "countStr");
-        CREATE_INDEX("scount", components::ql::index_compare::str, "countStr");
+        CREATE_INDEX("scount", core::type::str, "countStr");
+        CREATE_INDEX("scount", core::type::str, "countStr");
     }
 
     INFO("add existed dcount index") {
-        CREATE_INDEX("dcount", components::ql::index_compare::float64, "countDouble");
-        CREATE_INDEX("dcount", components::ql::index_compare::float64, "countDouble");
+        CREATE_INDEX("dcount", core::type::float64, "countDouble");
+        CREATE_INDEX("dcount", core::type::float64, "countDouble");
     }
 
     INFO("find") {
@@ -251,5 +251,104 @@ TEST_CASE("integration::test_index::index already exist") {
         CHECK_EXISTS_INDEX("ncount", true);
         CHECK_EXISTS_INDEX("scount", true);
         CHECK_EXISTS_INDEX("dcount", true);
+    }
+}
+
+TEST_CASE("integration::test_index::no_type base check") {
+    auto config = test_create_config("/tmp/otterbrix/integration/test_index/base");
+    test_clear_directory(config);
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    INFO("initialization") {
+        INIT_COLLECTION();
+        FILL_COLLECTION();
+        CREATE_INDEX("ncount", core::type::undef, "count");
+        CREATE_INDEX("dcount", core::type::undef, "countDouble");
+        CREATE_INDEX("scount", core::type::undef, "countStr");
+    }
+
+    INFO("check indexes") {
+        CHECK_EXISTS_INDEX("ncount", true);
+        CHECK_EXISTS_INDEX("dcount", true);
+        CHECK_EXISTS_INDEX("scount", true);
+    }
+
+    // Not working
+    // INFO("find"){
+    // CHECK_FIND_COUNT(compare_type::eq, 10, 1);
+    // CHECK_FIND_COUNT(compare_type::gt, 10, 90);
+    // CHECK_FIND_COUNT(compare_type::lt, 10, 9);
+    // CHECK_FIND_COUNT(compare_type::ne, 10, 99);
+    // CHECK_FIND_COUNT(compare_type::gte, 10, 91);
+    // CHECK_FIND_COUNT(compare_type::lte, 10, 10);
+    // }
+}
+
+TEST_CASE("integration::test_index::no_type pending base check") {
+    auto config = test_create_config("/tmp/otterbrix/integration/test_index/base");
+    test_clear_directory(config);
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    INFO("initialization") {
+        INIT_COLLECTION();
+        CREATE_INDEX("ncount", core::type::undef, "count");
+        CREATE_INDEX("dcount", core::type::undef, "countDouble");
+        CREATE_INDEX("scount", core::type::undef, "countStr");
+        FILL_COLLECTION();
+    }
+
+    INFO("check indexes") {
+        CHECK_EXISTS_INDEX("ncount", true);
+        CHECK_EXISTS_INDEX("dcount", true);
+        CHECK_EXISTS_INDEX("scount", true);
+    }
+
+    // Not working
+    // INFO("find"){
+    // CHECK_FIND_COUNT(compare_type::eq, 10, 1);
+    // CHECK_FIND_COUNT(compare_type::gt, 10, 90);
+    // CHECK_FIND_COUNT(compare_type::lt, 10, 9);
+    // CHECK_FIND_COUNT(compare_type::ne, 10, 99);
+    // CHECK_FIND_COUNT(compare_type::gte, 10, 91);
+    // CHECK_FIND_COUNT(compare_type::lte, 10, 10);
+    // }
+}
+
+// TODO this test is unstable
+TEST_CASE("integration::test_index::no_type save_load") {
+    auto config = test_create_config("/tmp/otterbrix/integration/test_index/save_load");
+    test_clear_directory(config);
+
+    INFO("initialization") {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+
+        INIT_COLLECTION();
+        CREATE_INDEX("ncount", core::type::undef, "count");
+        CREATE_INDEX("scount", core::type::undef, "countStr");
+        CREATE_INDEX("dcount", core::type::undef, "countDouble");
+        FILL_COLLECTION();
+    }
+
+    INFO("check indexes") {
+        CHECK_EXISTS_INDEX("ncount", true);
+        CHECK_EXISTS_INDEX("dcount", true);
+        CHECK_EXISTS_INDEX("scount", true);
+    }
+
+    INFO("find") {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+        dispatcher->load();
+
+        CHECK_FIND_ALL();
+        // CHECK_FIND_COUNT(compare_type::eq, 10, 1);
+        // CHECK_FIND_COUNT(compare_type::gt, 10, 90);
+        // CHECK_FIND_COUNT(compare_type::lt, 10, 9);
+        // CHECK_FIND_COUNT(compare_type::ne, 10, 99);
+        // CHECK_FIND_COUNT(compare_type::gte, 10, 91);
+        // CHECK_FIND_COUNT(compare_type::lte, 10, 10);
     }
 }

--- a/integration/python/main.cpp
+++ b/integration/python/main.cpp
@@ -19,6 +19,7 @@
 PYBIND11_DECLARE_HOLDER_TYPE(T, boost::intrusive_ptr<T>)
 
 using namespace otterbrix;
+using namespace core;
 
 PYBIND11_MODULE(otterbrix, m) {
     py::class_<wrapper_client>(m, "Client")
@@ -46,19 +47,19 @@ PYBIND11_MODULE(otterbrix, m) {
         .value("WILDCARD", index_type::wildcard)
         .export_values();
 
-    py::enum_<index_compare>(m, "CompareIndex")
-        .value("STR", index_compare::str)
-        .value("INT8", index_compare::int8)
-        .value("INT16", index_compare::int16)
-        .value("INT32", index_compare::int32)
-        .value("INT64", index_compare::int64)
-        .value("UINT8", index_compare::uint8)
-        .value("UINT16", index_compare::uint16)
-        .value("UINT32", index_compare::uint32)
-        .value("UINT64", index_compare::uint64)
-        .value("FLOAT32", index_compare::float32)
-        .value("FLOAT64", index_compare::float64)
-        .value("BOOL8", index_compare::bool8)
+    py::enum_<type>(m, "CompareIndex")
+        .value("STR", type::str)
+        .value("INT8", type::int8)
+        .value("INT16", type::int16)
+        .value("INT32", type::int32)
+        .value("INT64", type::int64)
+        .value("UINT8", type::uint8)
+        .value("UINT16", type::uint16)
+        .value("UINT32", type::uint32)
+        .value("UINT64", type::uint64)
+        .value("FLOAT32", type::float32)
+        .value("FLOAT64", type::float64)
+        .value("BOOL8", type::bool8)
         .export_values();
 
     py::class_<wrapper_collection, boost::intrusive_ptr<wrapper_collection>>(m, "Collection")

--- a/integration/python/wrapper_collection.cpp
+++ b/integration/python/wrapper_collection.cpp
@@ -238,7 +238,7 @@ namespace otterbrix {
         throw std::runtime_error("wrapper_collection::find");
     }
     */
-    bool wrapper_collection::create_index(const py::list& keys, index_type type, index_compare compare) {
+    bool wrapper_collection::create_index(const py::list& keys, index_type type, core::type compare) {
         debug(log_, "wrapper_collection::create_index: {}", name_);
         auto session_tmp = otterbrix::session_id_t();
         components::ql::create_index_t index(database_, name_, name_, type, compare);

--- a/integration/python/wrapper_collection.hpp
+++ b/integration/python/wrapper_collection.hpp
@@ -14,6 +14,7 @@
 #include <log/log.hpp>
 
 #include <components/ql/index.hpp>
+#include <core/types.hpp>
 
 #include "forward.hpp"
 #include "integration/cpp/wrapper_dispatcher.hpp"
@@ -22,7 +23,6 @@
 namespace py = pybind11;
 namespace otterbrix {
 
-    using components::ql::index_compare;
     using components::ql::index_type;
 
     class PYBIND11_EXPORT wrapper_collection final : public boost::intrusive_ref_counter<wrapper_collection> {
@@ -42,7 +42,7 @@ namespace otterbrix {
         wrapper_cursor_ptr delete_many(py::object cond);
         bool drop();
         ///auto aggregate(const py::sequence& it)-> wrapper_cursor_ptr;
-        bool create_index(const py::list& keys, index_type type, index_compare compare);
+        bool create_index(const py::list& keys, index_type type, core::type compare);
 
     private:
         const std::string name_;

--- a/services/collection/CMakeLists.txt
+++ b/services/collection/CMakeLists.txt
@@ -52,6 +52,7 @@ set(${PROJECT_NAME}_SOURCES
 
         collection.cpp
         create_index.cpp
+        create_index_utils.cpp
         sort.cpp
 )
 

--- a/services/collection/collection.hpp
+++ b/services/collection/collection.hpp
@@ -37,6 +37,11 @@ namespace services::collection {
 
     class collection_t;
 
+    struct pending_index_create {
+        components::ql::create_index_ptr index_ql{nullptr};
+        std::unique_ptr<components::pipeline::context_t> context{nullptr};
+    };
+
     class context_collection_t final {
     public:
         explicit context_collection_t(std::pmr::memory_resource* resource,
@@ -70,6 +75,8 @@ namespace services::collection {
 
         actor_zeta::address_t disk() noexcept { return mdisk_; }
 
+        std::vector<pending_index_create>& pending_indexes() noexcept { return pending_indexes_to_create; }
+
     private:
         std::pmr::memory_resource* resource_;
         components::index::index_engine_ptr index_engine_;
@@ -81,11 +88,12 @@ namespace services::collection {
         collection_full_name_t name_;
         /**
          * @brief Index create/drop context
-         * 
          */
         sessions::sessions_storage_t& sessions_;
         actor_zeta::address_t mdisk_;
         log_t log_;
+
+        std::vector<pending_index_create> pending_indexes_to_create;
     };
 
     class collection_t final : public actor_zeta::basic_async_actor {
@@ -107,7 +115,7 @@ namespace services::collection {
         void create_index_finish(const session_id_t& session,
                                  const std::string& name,
                                  const actor_zeta::address_t& index_address);
-        void create_index_finish_fail(const session_id_t& session, const std::string& name);
+        void create_index_finish_index_exist(const session_id_t& session, const std::string& name);
         void index_modify_finish(const session_id_t& session);
         void index_find_finish(const session_id_t& session, const std::pmr::vector<document_id_t>& result);
 

--- a/services/collection/create_index_utils.cpp
+++ b/services/collection/create_index_utils.cpp
@@ -1,0 +1,99 @@
+#include "create_index_utils.hpp"
+
+#include <components/index/disk/route.hpp>
+#include <components/index/single_field_index.hpp>
+
+namespace services::collection {
+
+    bool try_update_index_compare(const components::document::document_view_t& doc,
+                                  components::ql::create_index_ptr& index_ql) {
+        switch (index_ql->index_compare_) {
+            case core::type::undef: {
+                // TODO use types based on statistic
+                const auto deduced_type = doc.type_by_key(index_ql->keys_[0].as_string());
+                if (deduced_type == core::type::undef) {
+                    return false;
+                }
+                index_ql->index_compare_ = deduced_type;
+                return true;
+            }
+            default: {
+                // create_index already contains compare type
+                // TODO add comparability validation with documents
+                return true;
+            }
+        }
+    }
+
+    void create_index_impl(context_collection_t* context,
+                           components::pipeline::context_t* pipeline_context,
+                           components::ql::create_index_ptr index_ql,
+                           bool is_pending) {
+        trace(context->log(),
+              "create_index_impl session: {}, index: {}",
+              pipeline_context->session.data(),
+              index_ql->name());
+        switch (index_ql->index_type_) {
+            case components::ql::index_type::single: {
+                const bool index_exist = context->index_engine()->has_index(index_ql->name());
+                const auto id_index = index_exist
+                                          ? components::index::INDEX_ID_UNDEFINED
+                                          : components::index::make_index<components::index::single_field_index_t>(
+                                                context->index_engine(),
+                                                index_ql->name(),
+                                                index_ql->keys_);
+
+                services::collection::sessions::make_session(
+                    context->sessions(),
+                    pipeline_context->session,
+                    index_ql->name(),
+                    sessions::create_index_t{pipeline_context->current_message_sender, id_index, is_pending});
+                pipeline_context->send(context->disk(),
+                                       services::index::handler_id(services::index::route::create),
+                                       std::move(*(index_ql.release())));
+                break;
+            }
+            case components::ql::index_type::composite:
+            case components::ql::index_type::multikey:
+            case components::ql::index_type::hashed:
+            case components::ql::index_type::wildcard: {
+                trace(context->log(), "index_type not implemented");
+                assert(false && "index_type not implemented");
+                break;
+            }
+            case components::ql::index_type::no_valid: {
+                trace(context->log(), "index_type not implemented");
+                assert(false && "index_type not valid");
+                break;
+            }
+        }
+    }
+
+    void create_pending_index_impl(context_collection_t* context,
+                                   components::pipeline::context_t* pipeline_context,
+                                   components::ql::create_index_ptr index_ql) {
+        create_index_impl(context, pipeline_context, std::move(index_ql), true);
+    }
+
+    void process_pending_indexes(context_collection_t* context) {
+        // If doc exist and pending indexes not empty -> add curr ql to indexes and run loop
+        trace(context->log(), "Process pending indexes");
+
+        assert(!(context->storage().empty()) && "Require non empty document storage");
+
+        const auto doc_view = document_view_t(context->storage().begin()->second);
+        for (auto& [index, pipeline_context] : context->pending_indexes()) {
+            assert(index != nullptr && "pending index is null");
+            if (!try_update_index_compare(doc_view, index)) {
+                error(context->log(),
+                      "Can't deduce compare type for index: {} with key {}",
+                      index->name_,
+                      index->keys_.front().as_string());
+                continue;
+            }
+            create_pending_index_impl(context, pipeline_context.get(), std::move(index));
+        }
+        context->storage().clear();
+    }
+
+} // namespace services::collection

--- a/services/collection/create_index_utils.hpp
+++ b/services/collection/create_index_utils.hpp
@@ -1,0 +1,23 @@
+#pragma once
+#include <components/document/core/value.hpp>
+#include <components/document/document_view.hpp>
+#include <components/ql/index.hpp>
+#include <components/session/session.hpp>
+#include <services/collection/collection.hpp>
+
+namespace services::collection {
+
+    bool try_update_index_compare(const components::document::document_view_t& doc,
+                                  components::ql::create_index_ptr& index_ql);
+
+    void create_index_impl(context_collection_t* context,
+                           components::pipeline::context_t* pipeline_context,
+                           components::ql::create_index_ptr index_ql,
+                           bool is_pending = false);
+
+    void create_pending_index_impl(context_collection_t* context,
+                                   components::pipeline::context_t* pipeline_context,
+                                   components::ql::create_index_ptr index_ql);
+
+    void process_pending_indexes(context_collection_t* context);
+} // namespace services::collection

--- a/services/collection/operators/operator_add_index.cpp
+++ b/services/collection/operators/operator_add_index.cpp
@@ -1,7 +1,11 @@
 #include "operator_add_index.hpp"
+#include <components/cursor/cursor.hpp>
 #include <components/index/disk/route.hpp>
 #include <components/index/single_field_index.hpp>
+#include <core/pmr.hpp>
 #include <services/collection/collection.hpp>
+#include <services/collection/create_index_utils.hpp>
+#include <services/collection/route.hpp>
 #include <services/collection/session/session.hpp>
 #include <services/disk/index_disk.hpp>
 
@@ -9,43 +13,50 @@ namespace services::collection::operators {
 
     operator_add_index::operator_add_index(context_collection_t* context, components::ql::create_index_t* ql)
         : read_write_operator_t(context, operator_type::add_index)
-        , ql_{ql} {}
+        , index_ql_{ql} {}
 
     void operator_add_index::on_execute_impl(components::pipeline::context_t* pipeline_context) {
         trace(context_->log(),
               "operator_add_index::on_execute_impl session: {}, index: {}",
               pipeline_context->session.data(),
-              ql_->name());
-        switch (ql_->index_type_) {
-            case components::ql::index_type::single: {
-                const bool index_exist = context_->index_engine()->has_index(ql_->name());
-                const auto id_index = index_exist
-                                          ? components::index::INDEX_ID_UNDEFINED
-                                          : components::index::make_index<components::index::single_field_index_t>(
-                                                context_->index_engine(),
-                                                ql_->name(),
-                                                ql_->keys_);
-                services::collection::sessions::make_session(
-                    context_->sessions(),
-                    pipeline_context->session,
-                    ql_->name(),
-                    sessions::create_index_t{pipeline_context->current_message_sender, id_index});
-                pipeline_context->send(context_->disk(),
-                                       services::index::handler_id(services::index::route::create),
-                                       std::move(*(ql_.release())));
-                break;
-            }
-            case components::ql::index_type::composite:
-            case components::ql::index_type::multikey:
-            case components::ql::index_type::hashed:
-            case components::ql::index_type::wildcard: {
-                assert(false && "index_type not implemented");
-                break;
-            }
-            case components::ql::index_type::no_valid: {
-                assert(false && "index_type not valid");
-                break;
-            }
+              index_ql_->name());
+
+        // Index has pre setup compare type already
+        if (index_ql_->index_compare_ != core::type::undef) {
+            create_index_impl(context_, pipeline_context, std::move(index_ql_));
+            return;
         }
+
+        // If no documents exist and current index hasn't compare type, add to pending indexes vector
+        if (context_->storage().empty()) {
+            trace(context_->log(), "No documents found, add create_index to pending indexes");
+            pipeline_context->send(pipeline_context->current_message_sender,
+                                   services::collection::handler_id(services::collection::route::execute_plan_finish),
+                                   components::cursor::make_cursor(core::pmr::default_resource(),
+                                                                   components::cursor::operation_status_t::success));
+            context_->pending_indexes().emplace_back(
+                pending_index_create{std::make_unique<components::ql::create_index_t>(std::move(*index_ql_.get())),
+                                     std::make_unique<components::pipeline::context_t>(std::move(*pipeline_context))});
+            index_ql_.release();
+            return;
+        }
+
+        // Get view for first doc to retrieve types by key
+        const auto doc_view = document_view_t(context_->storage().begin()->second);
+
+        if (!try_update_index_compare(doc_view, index_ql_)) {
+            warn(context_->log(),
+                 "Can't deduce compare type for index: {} with key {}",
+                 index_ql_->name_,
+                 index_ql_->keys_.front().as_string());
+            pipeline_context->send(
+                pipeline_context->current_message_sender,
+                services::collection::handler_id(services::collection::route::execute_plan_finish),
+                components::cursor::make_cursor(core::pmr::default_resource(),
+                                                components::cursor::error_code_t::index_create_fail,
+                                                "index with name : " + index_ql_->name_ + " fail to deduce type"));
+            return;
+        }
+        create_index_impl(context_, pipeline_context, std::move(index_ql_));
     }
 } // namespace services::collection::operators

--- a/services/collection/operators/operator_add_index.hpp
+++ b/services/collection/operators/operator_add_index.hpp
@@ -13,7 +13,7 @@ namespace services::collection::operators {
     private:
         void on_execute_impl(components::pipeline::context_t* pipeline_context) final;
 
-        std::unique_ptr<components::ql::create_index_t> ql_;
+        components::ql::create_index_ptr index_ql_;
     };
 
 } // namespace services::collection::operators

--- a/services/collection/session/create_index.hpp
+++ b/services/collection/session/create_index.hpp
@@ -9,10 +9,12 @@ namespace services::collection::sessions {
     struct create_index_t : public session_base_t<create_index_t> {
         actor_zeta::address_t client;
         uint32_t id_index;
+        bool is_pending;
 
-        create_index_t(actor_zeta::address_t client, uint32_t id_index)
+        create_index_t(actor_zeta::address_t client, uint32_t id_index, bool is_pending = false)
             : client(std::move(client))
-            , id_index(id_index) {}
+            , id_index(id_index)
+            , is_pending(is_pending) {}
 
         static type_t type_impl() { return type_t::create_index; }
     };

--- a/services/disk/index_agent_disk.cpp
+++ b/services/disk/index_agent_disk.cpp
@@ -10,7 +10,7 @@ namespace services::disk {
                                            const path_t& path_db,
                                            const collection_name_t& collection_name,
                                            const index_name_t& index_name,
-                                           components::ql::index_compare compare_type,
+                                           core::type compare_type,
                                            log_t& log)
         : actor_zeta::basic_async_actor(manager, index_name)
         , resource_(resource)

--- a/services/disk/index_agent_disk.hpp
+++ b/services/disk/index_agent_disk.hpp
@@ -27,7 +27,7 @@ namespace services::disk {
                            const path_t&,
                            const collection_name_t&,
                            const index_name_t&,
-                           components::ql::index_compare compare_type,
+                           core::type compare_type,
                            log_t&);
         ~index_agent_disk_t() final;
 

--- a/services/disk/index_disk.cpp
+++ b/services/disk/index_disk.cpp
@@ -89,31 +89,31 @@ namespace services::disk {
     ADD_TYPE_SLICE(double, as_double)
     ADD_TYPE_SLICE(bool, as_bool)
 
-    std::unique_ptr<base_comparator> make_comparator(components::ql::index_compare compare_type) {
+    std::unique_ptr<base_comparator> make_comparator(core::type compare_type) {
         switch (compare_type) {
-            case components::ql::index_compare::str:
+            case core::type::str:
                 return std::make_unique<comparator<std::string>>();
-            case components::ql::index_compare::int8:
+            case core::type::int8:
                 return std::make_unique<comparator<int8_t>>();
-            case components::ql::index_compare::int16:
+            case core::type::int16:
                 return std::make_unique<comparator<int16_t>>();
-            case components::ql::index_compare::int32:
+            case core::type::int32:
                 return std::make_unique<comparator<int32_t>>();
-            case components::ql::index_compare::int64:
+            case core::type::int64:
                 return std::make_unique<comparator<int64_t>>();
-            case components::ql::index_compare::uint8:
+            case core::type::uint8:
                 return std::make_unique<comparator<uint8_t>>();
-            case components::ql::index_compare::uint16:
+            case core::type::uint16:
                 return std::make_unique<comparator<uint16_t>>();
-            case components::ql::index_compare::uint32:
+            case core::type::uint32:
                 return std::make_unique<comparator<uint32_t>>();
-            case components::ql::index_compare::uint64:
+            case core::type::uint64:
                 return std::make_unique<comparator<uint64_t>>();
-            case components::ql::index_compare::float32:
+            case core::type::float32:
                 return std::make_unique<comparator<float>>();
-            case components::ql::index_compare::float64:
+            case core::type::float64:
                 return std::make_unique<comparator<double>>();
-            case components::ql::index_compare::bool8:
+            case core::type::bool8:
                 return std::make_unique<comparator<bool>>();
         }
         return std::make_unique<comparator<std::string>>();
@@ -130,7 +130,7 @@ namespace services::disk {
         std::memcpy(docs.data() + size, slice.data(), slice.size());
     }
 
-    index_disk_t::index_disk_t(const path_t& path, components::ql::index_compare compare_type)
+    index_disk_t::index_disk_t(const path_t& path, core::type compare_type)
         : path_(path)
         , db_(nullptr)
         , comparator_(make_comparator(compare_type)) {

--- a/services/disk/index_disk.hpp
+++ b/services/disk/index_disk.hpp
@@ -23,7 +23,7 @@ namespace services::disk {
     public:
         using result = std::pmr::vector<document_id_t>;
 
-        index_disk_t(const path_t& path, components::ql::index_compare compare_type);
+        index_disk_t(const path_t& path, core::type compare_type);
         ~index_disk_t();
 
         void insert(const wrapper_value_t& key, const document_id_t& value);

--- a/services/disk/manager_disk.cpp
+++ b/services/disk/manager_disk.cpp
@@ -189,6 +189,7 @@ namespace services::disk {
 
     void manager_disk_t::create_index_agent(session_id_t& session, const components::ql::create_index_t& index) {
         auto name = index.name();
+        trace(log_, "manager_disk: create_index_agent : {}", name);
         if (index_agents_.contains(name) && !index_agents_.at(name)->is_dropped()) {
             error(log_, "manager_disk: index {} already exists", name);
             actor_zeta::send(current_message()->sender(),
@@ -385,14 +386,13 @@ namespace services::disk {
         actor_zeta::send(current_message()->sender(), address(), handler_id(route::load_finish), session, result);
     }
 
-    void manager_disk_empty_t::create_index_agent(session_id_t& session,
-                                                  const collection_name_t&,
-                                                  const index_name_t&,
-                                                  components::ql::index_compare) {
+    void manager_disk_empty_t::create_index_agent(session_id_t& session, const components::ql::create_index_t& index) {
+        auto name = index.name();
         actor_zeta::send(current_message()->sender(),
                          address(),
                          handler_id(index::route::success_create),
                          session,
+                         name,
                          actor_zeta::address_t::empty_address());
     }
 

--- a/services/disk/manager_disk.hpp
+++ b/services/disk/manager_disk.hpp
@@ -104,10 +104,7 @@ namespace services::disk {
         manager_disk_empty_t(actor_zeta::detail::pmr::memory_resource*, actor_zeta::scheduler_raw);
 
         auto load(session_id_t& session) -> void;
-        void create_index_agent(session_id_t& session,
-                                const collection_name_t&,
-                                const index_name_t&,
-                                components::ql::index_compare);
+        void create_index_agent(session_id_t& session, const components::ql::create_index_t& index);
 
         template<class... Args>
         auto nothing(Args&&...) -> void {}

--- a/services/disk/tests/test_index_disk.cpp
+++ b/services/disk/tests/test_index_disk.cpp
@@ -42,7 +42,7 @@ TEST_CASE("index_disk::string") {
     std::filesystem::path path{"/tmp/index_disk/string"};
     std::filesystem::remove_all(path);
     std::filesystem::create_directories(path);
-    auto index = index_disk_t(path, components::ql::index_compare::str);
+    auto index = index_disk_t(path, core::type::str);
 
     for (int i = 1; i <= 100; ++i) {
         index.insert(value_str(i), document_id_t{gen_id(i)});
@@ -73,7 +73,7 @@ TEST_CASE("index_disk::int32") {
     std::filesystem::path path{"/tmp/index_disk/int32"};
     std::filesystem::remove_all(path);
     std::filesystem::create_directories(path);
-    auto index = index_disk_t(path, components::ql::index_compare::int32);
+    auto index = index_disk_t(path, core::type::int32);
 
     for (int i = 1; i <= 100; ++i) {
         index.insert(value(int64_t(i)), document_id_t{gen_id(i)});
@@ -104,7 +104,7 @@ TEST_CASE("index_disk::uint32") {
     std::filesystem::path path{"/tmp/index_disk/uint32"};
     std::filesystem::remove_all(path);
     std::filesystem::create_directories(path);
-    auto index = index_disk_t(path, components::ql::index_compare::uint32);
+    auto index = index_disk_t(path, core::type::uint32);
 
     for (int i = 1; i <= 100; ++i) {
         index.insert(value(uint64_t(i)), document_id_t{gen_id(i)});
@@ -135,7 +135,7 @@ TEST_CASE("index_disk::double") {
     std::filesystem::path path{"/tmp/index_disk/double"};
     std::filesystem::remove_all(path);
     std::filesystem::create_directories(path);
-    auto index = index_disk_t(path, components::ql::index_compare::float64);
+    auto index = index_disk_t(path, core::type::float64);
 
     for (int i = 1; i <= 100; ++i) {
         index.insert(value(double(i)), document_id_t{gen_id(i)});
@@ -166,7 +166,7 @@ TEST_CASE("index_disk::multi_values::int32") {
     std::filesystem::path path{"/tmp/index_disk/int32_multi"};
     std::filesystem::remove_all(path);
     std::filesystem::create_directories(path);
-    auto index = index_disk_t(path, components::ql::index_compare::int32);
+    auto index = index_disk_t(path, core::type::int32);
 
     for (int i = 1; i <= 100; ++i) {
         for (int j = 0; j < 10; ++j) {


### PR DESCRIPTION
### Support SQL like indexes.
 - Now we can create indexes without compare type (type of field/key on which we create index)
 - Added pending indexes, when we don't have documents to deduce type, we create pending (waiting) index. When docs are added we resume index creation.
 - Add base type system for core type Value
 - Move index_compare types to core and rename to types
 
###  Main changes:
 - In class value_t added small schema type (types for documents value)
 - Add this schema to document and document view
 - Move to separate functions internals of operator_add_index to create_index_utils. Require for pending indexes logic
 - Add integration tests for indexes (has some issue, require further investigation)
 - Add SQL index tests (has some issue, require further investigation)

### Need to do:
- Pending indexes doesn't work good with WAL
- Pending indexes break some tests (see integration/cpp/test/test_index.cpp,  integration/cpp/test/test_collection_sql.cpp)