### PR TITLE
Fix CI clang-format issue

### DIFF
--- a/.github/workflows/ubuntu-20-04.yaml
+++ b/.github/workflows/ubuntu-20-04.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Install system dependencies
         run: |
-          sudo apt update && sudo apt install -y  build-essential ninja-build python3-pip python3-dev curl gnupg apt-transport-https clang-format-12
+          sudo apt update && sudo apt install -y  build-essential ninja-build python3-pip python3-dev curl gnupg apt-transport-https clang-format-11
           pip3 install termcolor
 
       - name: conan installation and configuration

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,6 @@
 #### Git hooks
 
-We have only pre-commit hook. Run script from the root directory of project to setup it. We use clang-format-12.
+We have only pre-commit hook. Run script from the root directory of project to setup it. We use clang-format-11.
 If you need to commit without formatting for some reson use --no-verify
 
 ./scripts/bootstrap.sh

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -8,4 +8,4 @@ components \
 core \
 example \
 integration \
-services 
+services

--- a/scripts/tools/code-fromat.py
+++ b/scripts/tools/code-fromat.py
@@ -10,8 +10,9 @@ from common import sys_call, collect_files_by_ext
 from termcolor import colored
 
 clang_versions = [
-  "clang-format-13",
+  "clang-format-11",
   "clang-format-12",
+  "clang-format-13",
   "/usr/local/opt/llvm/bin/clang-format", # llvm binaries installed by brew (keg only)
   "/opt/homebrew/bin/clang-format"
 ]
@@ -47,8 +48,15 @@ class Clang:
     if not clang_cmd:
       print("Can't find clang binary")
       sys.exit(1)
-      
+
     print(f"Found clang-format: {clang_cmd}")
+    cmd = "{} --version ".format(clang_cmd)
+    result, output = sys_call(cmd,
+                      working_dir=os.getcwd(),
+                      use_pipe=True)
+    if result:
+      s = output.decode("utf-8")
+      print(s)
 
     return clang_cmd
 


### PR DESCRIPTION
For some reason clang-format-12 in CI and local version of it lead to slightly different formatting. Downgrade to clang-format-11 helps to keep same format.