### PR TITLE
fix(index): Direct move ql for indexes

### DIFF
--- a/components/cursor/cursor.hpp
+++ b/components/cursor/cursor.hpp
@@ -2,7 +2,7 @@
 
 #include <vector>
 
-#include <actor-zeta/actor-zeta.hpp>
+#include <actor-zeta.hpp>
 
 #include <components/base/collection_full_name.hpp>
 #include <components/document/document.hpp>

--- a/components/logical_plan/node_create_index.cpp
+++ b/components/logical_plan/node_create_index.cpp
@@ -10,7 +10,7 @@ namespace components::logical_plan {
         : node_t(resource, node_type::create_index_t, collection)
         , ql_{ql} {}
 
-    components::ql::create_index_t* node_create_index_t::get_ql() const { return ql_.release(); }
+    std::unique_ptr<components::ql::create_index_t> node_create_index_t::get_ql() const { return std::move(ql_); }
 
     hash_t node_create_index_t::hash_impl() const { return 0; }
 

--- a/components/logical_plan/node_create_index.hpp
+++ b/components/logical_plan/node_create_index.hpp
@@ -12,7 +12,7 @@ namespace components::logical_plan {
                                      const collection_full_name_t& collection,
                                      components::ql::create_index_t* ql);
 
-        components::ql::create_index_t* get_ql() const;
+        std::unique_ptr<components::ql::create_index_t> get_ql() const;
 
     private:
         hash_t hash_impl() const final;

--- a/components/physical_plan/collection/operators/operator_add_index.cpp
+++ b/components/physical_plan/collection/operators/operator_add_index.cpp
@@ -10,9 +10,9 @@
 
 namespace services::collection::operators {
 
-    operator_add_index::operator_add_index(context_collection_t* context, components::ql::create_index_t* ql)
+    operator_add_index::operator_add_index(context_collection_t* context, components::ql::create_index_ptr ql)
         : read_write_operator_t(context, operator_type::add_index)
-        , index_ql_{ql} {}
+        , index_ql_{std::move(ql)} {}
 
     void operator_add_index::on_execute_impl(components::pipeline::context_t* pipeline_context) {
         trace(context_->log(),

--- a/components/physical_plan/collection/operators/operator_add_index.hpp
+++ b/components/physical_plan/collection/operators/operator_add_index.hpp
@@ -8,7 +8,7 @@ namespace services::collection::operators {
 
     class operator_add_index final : public read_write_operator_t {
     public:
-        operator_add_index(context_collection_t* context, components::ql::create_index_t* ql);
+        operator_add_index(context_collection_t* context, components::ql::create_index_ptr ql);
 
     private:
         void on_execute_impl(components::pipeline::context_t* pipeline_context) final;


### PR DESCRIPTION
Instead of releasing and create new `unique_ptr<index_ql>` in `operator_add_index` just move it from logical plan `node_create_index`.