### PR TITLE
Upload versions by wildcard in GHA

### DIFF
--- a/.github/workflows/manylinux2014.yml
+++ b/.github/workflows/manylinux2014.yml
@@ -100,8 +100,8 @@ jobs:
       - name: Save library
         uses: actions/upload-artifact@v4
         with:
-          name: artifact-wheel-${{ env.PYTHON_SHORT_VERSION }}-cp${{ env.PYTHON_SHORT_VERSION }}
-          path: ./work/dist/otterbrix*${{ env.PYTHON_SHORT_VERSION }}-cp${{ env.PYTHON_SHORT_VERSION }}-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+          name: artifact-wheel-${{ env.PYTHON_SHORT_VERSION }}
+          path: ./work/dist/otterbrix*cp${{ env.PYTHON_SHORT_VERSION }}*.whl
 
   test-wheel:
     name: Test wheel
@@ -138,7 +138,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v4.1.7
         with:
-          name: artifact-wheel-${{ env.PYTHON_SHORT_VERSION }}-cp${{ env.PYTHON_SHORT_VERSION }}
+          name: artifact-wheel-${{ env.PYTHON_SHORT_VERSION }}
           path: ./app
 
       - name: Inspect artifacts
@@ -192,7 +192,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v4.1.7
         with:
-          name: artifact-wheel-${{ env.PYTHON_SHORT_VERSION }}-cp${{ env.PYTHON_SHORT_VERSION }}
+          name: artifact-wheel-${{ env.PYTHON_SHORT_VERSION }}
           path: ./app
 
       - name: Inspect artifacts

--- a/.github/workflows/manylinux2014.yml
+++ b/.github/workflows/manylinux2014.yml
@@ -136,7 +136,7 @@ jobs:
 
 
       - name: Download artifact
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4
         with:
           name: artifact-wheel-${{ env.PYTHON_SHORT_VERSION }}
           path: ./app
@@ -190,7 +190,7 @@ jobs:
           sudo apt install -y python3-pip
 
       - name: Download artifact
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4
         with:
           name: artifact-wheel-${{ env.PYTHON_SHORT_VERSION }}
           path: ./app

--- a/.github/workflows/manylinux2014.yml
+++ b/.github/workflows/manylinux2014.yml
@@ -100,7 +100,8 @@ jobs:
       - name: Save library
         uses: actions/upload-artifact@v4
         with:
-          name: ./work/dist/otterbrix*${{ env.PYTHON_SHORT_VERSION }}-cp${{ env.PYTHON_SHORT_VERSION }}-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+          name: artifact-wheel-${{ env.PYTHON_SHORT_VERSION }}-cp${{ env.PYTHON_SHORT_VERSION }}
+          path: ./work/dist/otterbrix*${{ env.PYTHON_SHORT_VERSION }}-cp${{ env.PYTHON_SHORT_VERSION }}-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
 
   test-wheel:
     name: Test wheel
@@ -137,8 +138,12 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v4.1.7
         with:
-          name: otterbrix-1.0a9-cp${{ env.PYTHON_SHORT_VERSION }}-cp${{ env.PYTHON_SHORT_VERSION }}-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+          name: artifact-wheel-${{ env.PYTHON_SHORT_VERSION }}-cp${{ env.PYTHON_SHORT_VERSION }}
           path: ./app
+
+      - name: Inspect artifacts
+        run: |
+          ls -l ./app/*whl
 
       - name: Install package from wheel
         run: |
@@ -184,10 +189,15 @@ jobs:
           sudo apt update 
           sudo apt install -y python3-pip
 
-      - uses: actions/download-artifact@v4.1.7
+      - name: Download artifact
+        uses: actions/download-artifact@v4.1.7
         with:
-          name: otterbrix-1.0a9-cp${{ env.PYTHON_SHORT_VERSION }}-cp${{ env.PYTHON_SHORT_VERSION }}-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+          name: artifact-wheel-${{ env.PYTHON_SHORT_VERSION }}-cp${{ env.PYTHON_SHORT_VERSION }}
           path: ./app
+
+      - name: Inspect artifacts
+        run: |
+          ls -l ./app/*whl
 
       - name: Install twine
         run: |

--- a/.github/workflows/manylinux2014.yml
+++ b/.github/workflows/manylinux2014.yml
@@ -100,8 +100,7 @@ jobs:
       - name: Save library
         uses: actions/upload-artifact@v4
         with:
-          path: ./work/dist/
-          name: otterbrix-1.0a9-cp${{ env.PYTHON_SHORT_VERSION }}-cp${{ env.PYTHON_SHORT_VERSION }}-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+          name: ./work/dist/otterbrix*${{ env.PYTHON_SHORT_VERSION }}-cp${{ env.PYTHON_SHORT_VERSION }}-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
 
   test-wheel:
     name: Test wheel


### PR DESCRIPTION
Instead of hardcoding version numbers in GitHub actions, let's use wildcards. So the version will be only specified in `setup.py`