### PR TITLE
Breaking CMake circular dependency

### DIFF
--- a/components/expressions/update_expression.cpp
+++ b/components/expressions/update_expression.cpp
@@ -135,7 +135,9 @@ namespace components::expressions {
 
     update_expr_ptr update_expr_set_t::deserialize(serializer::base_deserializer_t* deserializer) {
         update_expr_ptr res = new update_expr_set_t(deserializer->deserialize_key(2));
-        res->left() = deserializer->deserialize_update_expression(3);
+        deserializer->advance_array(3);
+        res->left() = update_expr_t::deserialize(deserializer);
+        deserializer->pop_array();
         return res;
     }
 
@@ -245,8 +247,12 @@ namespace components::expressions {
 
     update_expr_ptr update_expr_calculate_t::deserialize(serializer::base_deserializer_t* deserializer) {
         update_expr_ptr res = new update_expr_calculate_t(deserializer->deserialize_update_expr_type(1));
-        res->left() = deserializer->deserialize_update_expression(2);
-        res->right() = deserializer->deserialize_update_expression(3);
+        deserializer->advance_array(2);
+        res->left() = update_expr_t::deserialize(deserializer);
+        deserializer->pop_array();
+        deserializer->advance_array(3);
+        res->right() = update_expr_t::deserialize(deserializer);
+        deserializer->pop_array();
         return res;
     }
 

--- a/components/logical_plan/node_aggregate.cpp
+++ b/components/logical_plan/node_aggregate.cpp
@@ -14,10 +14,14 @@ namespace components::logical_plan {
     node_ptr node_aggregate_t::deserialize(serializer::base_deserializer_t* deserializer) {
         collection_full_name_t collection = deserializer->deserialize_collection(1);
         auto res = make_node_aggregate(deserializer->resource(), collection);
-        auto children = deserializer->deserialize_nodes(2);
-        for (const auto& child : children) {
-            res->append_child(child);
+
+        deserializer->advance_array(2);
+        for (size_t i = 0; i < deserializer->current_array_size(); i++) {
+            deserializer->advance_array(i);
+            res->append_child(node_t::deserialize(deserializer));
+            deserializer->pop_array();
         }
+        deserializer->pop_array();
         return res;
     }
 

--- a/components/logical_plan/node_delete.cpp
+++ b/components/logical_plan/node_delete.cpp
@@ -24,11 +24,20 @@ namespace components::logical_plan {
 
     node_ptr node_delete_t::deserialize(serializer::base_deserializer_t* deserializer) {
         collection_full_name_t collection = deserializer->deserialize_collection(1);
-        auto children = deserializer->deserialize_nodes(2);
+
+        deserializer->advance_array(2);
+        deserializer->advance_array(0);
+        auto match = node_match_t::deserialize(deserializer);
+        deserializer->pop_array();
+        deserializer->advance_array(1);
+        auto limit = node_limit_t::deserialize(deserializer);
+        deserializer->pop_array();
+        deserializer->pop_array();
+
         return make_node_delete(deserializer->resource(),
                                 collection,
-                                reinterpret_cast<const node_match_ptr&>(children.at(0)),
-                                reinterpret_cast<const node_limit_ptr&>(children.at(1)));
+                                reinterpret_cast<const node_match_ptr&>(match),
+                                reinterpret_cast<const node_limit_ptr&>(limit));
     }
 
     hash_t node_delete_t::hash_impl() const { return 0; }

--- a/components/logical_plan/node_insert.cpp
+++ b/components/logical_plan/node_insert.cpp
@@ -23,11 +23,16 @@ namespace components::logical_plan {
 
     node_ptr node_insert_t::deserialize(serializer::base_deserializer_t* deserializer) {
         auto collection = deserializer->deserialize_collection(1);
-        auto children = deserializer->deserialize_nodes(2);
+
         auto res = make_node_insert(deserializer->resource(), collection);
-        for (const auto& child : children) {
-            res->append_child(child);
+        deserializer->advance_array(2);
+        for (size_t i = 0; i < deserializer->current_array_size(); i++) {
+            deserializer->advance_array(i);
+            res->append_child(node_t::deserialize(deserializer));
+            deserializer->pop_array();
         }
+        deserializer->pop_array();
+
         std::pmr::vector<std::pair<expressions::key_t, expressions::key_t>> key_translation(deserializer->resource());
         deserializer->advance_array(3);
         for (size_t i = 0; i < deserializer->current_array_size(); i++) {

--- a/components/logical_plan/node_join.cpp
+++ b/components/logical_plan/node_join.cpp
@@ -19,11 +19,15 @@ namespace components::logical_plan {
     node_ptr node_join_t::deserialize(serializer::base_deserializer_t* deserializer) {
         auto type = deserializer->deserialize_join_type(1);
         auto collection = deserializer->deserialize_collection(2);
-        auto children = deserializer->deserialize_nodes(3);
         auto res = make_node_join(deserializer->resource(), collection, type);
-        for (const auto& child : children) {
-            res->append_child(child);
+        deserializer->advance_array(3);
+        for (size_t i = 0; i < deserializer->current_array_size(); i++) {
+            deserializer->advance_array(i);
+            res->append_child(node_t::deserialize(deserializer));
+            deserializer->pop_array();
         }
+        deserializer->pop_array();
+
         return res;
     }
 

--- a/components/logical_plan/node_limit.cpp
+++ b/components/logical_plan/node_limit.cpp
@@ -29,7 +29,7 @@ namespace components::logical_plan {
 
     node_ptr node_limit_t::deserialize(serializer::base_deserializer_t* deserializer) {
         auto collection = deserializer->deserialize_collection(1);
-        auto limit = deserializer->deserialize_limit(2);
+        auto limit = limit_t(deserializer->deserialize_int64(2));
         return make_node_limit(deserializer->resource(), collection, limit);
     }
 
@@ -45,7 +45,7 @@ namespace components::logical_plan {
         serializer->start_array(3);
         serializer->append("type", serializer::serialization_type::logical_node_limit);
         serializer->append("collection", collection_);
-        serializer->append("limit", limit_);
+        serializer->append("limit", static_cast<int64_t>(limit_.limit()));
         serializer->end_array();
     }
 

--- a/components/serialization/CMakeLists.txt
+++ b/components/serialization/CMakeLists.txt
@@ -15,10 +15,8 @@ set_property(TARGET otterbrix_${PROJECT_NAME} PROPERTY EXPORT_NAME ${PROJECT_NAM
 
 target_link_libraries(
         otterbrix_${PROJECT_NAME} PRIVATE
-        otterbrix::logical_plan
         otterbrix::document
         otterbrix::types
-        otterbrix::expressions
         magic_enum::magic_enum
         msgpackc-cxx
         absl::int128

--- a/components/serialization/deserializer.hpp
+++ b/components/serialization/deserializer.hpp
@@ -14,7 +14,6 @@ namespace components::serializer {
 
         std::pmr::memory_resource* resource() const { return input_.get_allocator().resource(); }
 
-        deserialization_result deserialize(size_t index);
         virtual size_t root_array_size() const = 0;
         virtual size_t current_array_size() const = 0;
         virtual void advance_array(size_t index) = 0;
@@ -22,6 +21,7 @@ namespace components::serializer {
         virtual serialization_type current_type() = 0;
 
         virtual bool deserialize_bool(size_t index) = 0;
+        virtual int64_t deserialize_int64(size_t index) = 0;
         virtual uint64_t deserialize_uint64(size_t index) = 0;
         virtual expressions::aggregate_type deserialize_aggregate_type(size_t index) = 0;
         virtual expressions::compare_type deserialize_compare_type(size_t index) = 0;
@@ -31,7 +31,6 @@ namespace components::serializer {
         virtual expressions::update_expr_get_value_t::side_t deserialize_update_expr_side(size_t index) = 0;
         virtual logical_plan::index_type deserialize_index_type(size_t index) = 0;
         virtual logical_plan::join_type deserialize_join_type(size_t index) = 0;
-        virtual logical_plan::limit_t deserialize_limit(size_t index) = 0;
         virtual core::parameter_id_t deserialize_param_id(size_t index) = 0;
         virtual expressions::key_t deserialize_key(size_t index) = 0;
         virtual std::string deserialize_string(size_t index) = 0;
@@ -44,16 +43,11 @@ namespace components::serializer {
         std::pmr::vector<expressions::key_t> deserialize_keys(size_t index);
         std::pmr::vector<expressions::param_storage> deserialize_param_storages(size_t index);
         std::pmr::vector<document_ptr> deserialize_documents(size_t index);
-        std::pmr::vector<logical_plan::node_ptr> deserialize_nodes(size_t index);
         std::pmr::vector<expressions::expression_ptr> deserialize_expressions(size_t index);
-        std::pmr::vector<expressions::update_expr_ptr> deserialize_update_expressions(size_t index);
         std::pair<core::parameter_id_t, document::value_t> deserialize_param_pair(document::impl::base_document* tape,
                                                                                   size_t size);
 
-        logical_plan::node_ptr deserialize_logical_node(size_t index);
         expressions::expression_ptr deserialize_expression(size_t index);
-        expressions::update_expr_ptr deserialize_update_expression(size_t index);
-        logical_plan::parameter_node_ptr deserialize_parameters(size_t index);
 
     protected:
         std::pmr::string input_;
@@ -70,6 +64,7 @@ namespace components::serializer {
         serialization_type current_type() override;
 
         bool deserialize_bool(size_t index) override;
+        int64_t deserialize_int64(size_t index) override;
         uint64_t deserialize_uint64(size_t index) override;
         expressions::aggregate_type deserialize_aggregate_type(size_t index) override;
         expressions::compare_type deserialize_compare_type(size_t index) override;
@@ -79,7 +74,6 @@ namespace components::serializer {
         expressions::update_expr_get_value_t::side_t deserialize_update_expr_side(size_t index) override;
         logical_plan::index_type deserialize_index_type(size_t index) override;
         logical_plan::join_type deserialize_join_type(size_t index) override;
-        logical_plan::limit_t deserialize_limit(size_t index) override;
         core::parameter_id_t deserialize_param_id(size_t index) override;
         expressions::key_t deserialize_key(size_t index) override;
         std::string deserialize_string(size_t index) override;
@@ -104,6 +98,7 @@ namespace components::serializer {
         serialization_type current_type() override;
 
         bool deserialize_bool(size_t index) override;
+        int64_t deserialize_int64(size_t index) override;
         uint64_t deserialize_uint64(size_t index) override;
         expressions::aggregate_type deserialize_aggregate_type(size_t index) override;
         expressions::compare_type deserialize_compare_type(size_t index) override;
@@ -113,7 +108,6 @@ namespace components::serializer {
         expressions::update_expr_get_value_t::side_t deserialize_update_expr_side(size_t index) override;
         logical_plan::index_type deserialize_index_type(size_t index) override;
         logical_plan::join_type deserialize_join_type(size_t index) override;
-        logical_plan::limit_t deserialize_limit(size_t index) override;
         core::parameter_id_t deserialize_param_id(size_t index) override;
         expressions::key_t deserialize_key(size_t index) override;
         std::string deserialize_string(size_t index) override;

--- a/components/serialization/serializer.cpp
+++ b/components/serialization/serializer.cpp
@@ -103,10 +103,6 @@ namespace components::serializer {
         expr->serialize(this);
     }
 
-    void base_serializer_t::append(std::string_view key, const logical_plan::parameter_node_ptr& params) {
-        params->serialize(this);
-    }
-
     // TODO: use memory_resource to initialize root_arr_
     json_serializer_t::json_serializer_t(std::pmr::memory_resource* resource)
         : base_serializer_t(resource) {}
@@ -130,6 +126,8 @@ namespace components::serializer {
     }
 
     void json_serializer_t::append(std::string_view key, bool val) { working_tree_.top()->emplace_back(val); }
+
+    void json_serializer_t::append(std::string_view key, int64_t val) { working_tree_.top()->emplace_back(val); }
 
     void json_serializer_t::append(std::string_view key, uint64_t val) { working_tree_.top()->emplace_back(val); }
 
@@ -175,10 +173,6 @@ namespace components::serializer {
 
     void json_serializer_t::append(std::string_view key, expressions::update_expr_get_value_t::side_t side) {
         working_tree_.top()->emplace_back(static_cast<uint8_t>(side));
-    }
-
-    void json_serializer_t::append(std::string_view key, logical_plan::limit_t limit) {
-        working_tree_.top()->emplace_back(limit.limit());
     }
 
     void json_serializer_t::append(std::string_view key, const std::string& str) {
@@ -247,6 +241,8 @@ namespace components::serializer {
 
     void msgpack_serializer_t::append(std::string_view key, bool val) { packer_.pack(val); }
 
+    void msgpack_serializer_t::append(std::string_view key, int64_t val) { packer_.pack(val); }
+
     void msgpack_serializer_t::append(std::string_view key, uint64_t val) { packer_.pack(val); }
 
     void msgpack_serializer_t::append(std::string_view key, core::parameter_id_t val) { packer_.pack(val.t); }
@@ -289,10 +285,6 @@ namespace components::serializer {
 
     void msgpack_serializer_t::append(std::string_view key, expressions::update_expr_get_value_t::side_t side) {
         packer_.pack(static_cast<uint8_t>(side));
-    }
-
-    void msgpack_serializer_t::append(std::string_view key, logical_plan::limit_t limit) {
-        packer_.pack(limit.limit());
     }
 
     void msgpack_serializer_t::append(std::string_view key, const std::string& str) { packer_.pack(str); }

--- a/components/serialization/serializer.hpp
+++ b/components/serialization/serializer.hpp
@@ -55,9 +55,6 @@ namespace components::serializer {
         invalid = 255
     };
 
-    // TODO:
-    // This is a prototype serializer with extreamly specialized methods
-    // Future versions will be simplified
     class base_serializer_t {
     public:
         explicit base_serializer_t(std::pmr::memory_resource* resource);
@@ -69,6 +66,7 @@ namespace components::serializer {
         virtual void end_array() = 0;
 
         virtual void append(std::string_view key, bool val) = 0;
+        virtual void append(std::string_view key, int64_t val) = 0;
         virtual void append(std::string_view key, uint64_t val) = 0;
         virtual void append(std::string_view key, core::parameter_id_t val) = 0;
         virtual void append(std::string_view key, serialization_type type) = 0;
@@ -81,7 +79,6 @@ namespace components::serializer {
         virtual void append(std::string_view key, expressions::sort_order order) = 0;
         virtual void append(std::string_view key, expressions::update_expr_type type) = 0;
         virtual void append(std::string_view key, expressions::update_expr_get_value_t::side_t side) = 0;
-        virtual void append(std::string_view key, logical_plan::limit_t limit) = 0;
 
         void append(std::string_view key, const std::pmr::vector<logical_plan::node_ptr>& nodes);
         void append(std::string_view key, const std::pmr::vector<document::document_ptr>& documents);
@@ -101,7 +98,6 @@ namespace components::serializer {
         void append(std::string_view key, const logical_plan::node_ptr& node);
         void append(std::string_view key, const expressions::expression_ptr& expr);
         void append(std::string_view key, const expressions::update_expr_ptr& expr);
-        void append(std::string_view key, const logical_plan::parameter_node_ptr& params);
 
     protected:
         pmr_string_stream result_;
@@ -117,6 +113,7 @@ namespace components::serializer {
         void end_array() override;
 
         void append(std::string_view key, bool val) override;
+        void append(std::string_view key, int64_t val) override;
         void append(std::string_view key, uint64_t val) override;
         void append(std::string_view key, core::parameter_id_t val) override;
         void append(std::string_view key, serialization_type type) override;
@@ -129,7 +126,6 @@ namespace components::serializer {
         void append(std::string_view key, expressions::sort_order order) override;
         void append(std::string_view key, expressions::update_expr_type type) override;
         void append(std::string_view key, expressions::update_expr_get_value_t::side_t side) override;
-        void append(std::string_view key, logical_plan::limit_t limit) override;
         void append(std::string_view key, const std::string& str) override;
         void append(std::string_view key, const document::document_ptr& doc) override;
         void append(std::string_view key, const document::value_t& val) override;
@@ -150,6 +146,7 @@ namespace components::serializer {
         void end_array() override;
 
         void append(std::string_view key, bool val) override;
+        void append(std::string_view key, int64_t val) override;
         void append(std::string_view key, uint64_t val) override;
         void append(std::string_view key, core::parameter_id_t val) override;
         void append(std::string_view key, serialization_type type) override;
@@ -162,7 +159,6 @@ namespace components::serializer {
         void append(std::string_view key, expressions::sort_order order) override;
         void append(std::string_view key, expressions::update_expr_type type) override;
         void append(std::string_view key, expressions::update_expr_get_value_t::side_t side) override;
-        void append(std::string_view key, logical_plan::limit_t limit) override;
         void append(std::string_view key, const std::string& str) override;
         void append(std::string_view key, const document::document_ptr& doc) override;
         void append(std::string_view key, const document::value_t& val) override;

--- a/services/disk/manager_disk.cpp
+++ b/services/disk/manager_disk.cpp
@@ -422,7 +422,10 @@ namespace services::disk {
                     metafile_indexes_->read(buf.data(), size, offset);
                     offset += std::int64_t(size);
                     components::serializer::msgpack_deserializer_t deserializer(buf);
-                    auto index = deserializer.deserialize_logical_node(0);
+
+                    deserializer.advance_array(0);
+                    auto index = components::logical_plan::node_t::deserialize(&deserializer);
+                    deserializer.pop_array();
                     if (collection.empty() || index->collection_name() == collection) {
                         res.push_back(reinterpret_cast<const components::logical_plan::node_create_index_ptr&>(index));
                     }

--- a/services/wal/dto.cpp
+++ b/services/wal/dto.cpp
@@ -68,7 +68,7 @@ namespace services::wal {
         serializer.append("crc", static_cast<uint64_t>(last_crc32));
         serializer.append("id", static_cast<uint64_t>(id));
         serializer.append("node", data);
-        serializer.append("params", params);
+        params->serialize(&serializer);
         serializer.end_array();
         auto buffer = serializer.result();
 
@@ -80,8 +80,13 @@ namespace services::wal {
 
         entry.last_crc32_ = deserializer.deserialize_uint64(0);
         entry.id_ = deserializer.deserialize_uint64(1);
-        entry.entry_ = deserializer.deserialize_logical_node(2);
-        entry.params_ = deserializer.deserialize_parameters(3);
+
+        deserializer.advance_array(2);
+        entry.entry_ = components::logical_plan::node_t::deserialize(&deserializer);
+        deserializer.pop_array();
+        deserializer.advance_array(3);
+        entry.params_ = components::logical_plan::parameter_node_t::deserialize(&deserializer);
+        deserializer.pop_array();
     }
 
     id_t unpack_wal_id(buffer_t& storage) {

--- a/services/wal/wal.cpp
+++ b/services/wal/wal.cpp
@@ -400,8 +400,13 @@ namespace services::wal {
                 components::serializer::msgpack_deserializer_t deserializer(output);
                 record.last_crc32 = deserializer.deserialize_uint64(0);
                 record.id = deserializer.deserialize_uint64(1);
-                record.data = deserializer.deserialize_logical_node(2);
-                record.params = deserializer.deserialize_parameters(3);
+
+                deserializer.advance_array(2);
+                record.data = components::logical_plan::node_t::deserialize(&deserializer);
+                deserializer.pop_array();
+                deserializer.advance_array(3);
+                record.params = components::logical_plan::parameter_node_t::deserialize(&deserializer);
+                deserializer.pop_array();
             } else {
                 record.data = nullptr;
                 //todo: error wal content


### PR DESCRIPTION
Building otterbrix, when each component is a shared library was not possible because of circular dependency in expressions-logical plan-serialization