### PR TITLE
Default constructor for unified_vector_format

### DIFF
--- a/components/vector/vector.cpp
+++ b/components/vector/vector.cpp
@@ -7,6 +7,7 @@
 
 namespace components::vector {
 
+    unified_vector_format::unified_vector_format() : validity(nullptr) {}
     unified_vector_format::unified_vector_format(std::pmr::memory_resource* resource, uint64_t capacity)
         : validity(resource, capacity) {}
 

--- a/components/vector/vector.hpp
+++ b/components/vector/vector.hpp
@@ -30,6 +30,7 @@ namespace components::vector {
     }
 
     struct unified_vector_format {
+        unified_vector_format();
         unified_vector_format(std::pmr::memory_resource* resource, uint64_t capacity);
         unified_vector_format(const unified_vector_format& other) = delete;
         unified_vector_format& operator=(const unified_vector_format& other) = delete;


### PR DESCRIPTION
vector_t::to_unified_format (https://github.com/duckstax/otterbrix/blob/5d3538e890126c5224801cec3f2c16f017021d74/components/vector/vector.hpp#L141) updates unified_vector_format. There's no reason to create a non-empty unified_vector_format for this function.